### PR TITLE
Stop pretrained embeddings from loading during inference

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -43,7 +43,10 @@ def main(args):
 
     # Load ensemble
     print('| loading model(s) from {}'.format(', '.join(args.path)))
-    models, _ = utils.load_ensemble_for_inference(args.path, dataset.src_dict, dataset.dst_dict)
+    models, _ = utils.load_ensemble_for_inference(args.path, dataset.src_dict, dataset.dst_dict, model_arg_overrides={
+                'encoder_embed_path': None,
+                'decoder_embed_path': None
+            })
 
     print('| [{}] dictionary: {} types'.format(dataset.src, len(dataset.src_dict)))
     print('| [{}] dictionary: {} types'.format(dataset.dst, len(dataset.dst_dict)))

--- a/interactive.py
+++ b/interactive.py
@@ -25,7 +25,10 @@ def main(args):
 
     # Load ensemble
     print('| loading model(s) from {}'.format(', '.join(args.path)))
-    models, model_args = utils.load_ensemble_for_inference(args.path, data_dir=args.data)
+    models, model_args = utils.load_ensemble_for_inference(args.path, data_dir=args.data, model_arg_overrides={
+                'encoder_embed_path': None,
+                'decoder_embed_path': None
+            })
     src_dict, dst_dict = models[0].src_dict, models[0].dst_dict
 
     print('| [{}] dictionary: {} types'.format(model_args.source_lang, len(src_dict)))


### PR DESCRIPTION
In interactive.py and generate.py , if we try to load a model which was trained pre trained embeddings, it will try to load the files, eventhough the model checkpoints files we give have the embedding weights.