### PR TITLE
add count for padding words

### DIFF
--- a/fairseq/data/dictionary.py
+++ b/fairseq/data/dictionary.py
@@ -125,6 +125,7 @@ class Dictionary(object):
             i = 0
             while threshold_nwords % padding_factor != 0:
                 new_symbols.append('madeupword{:04d}'.format(i))
+                new_count.append(0)
                 i += 1
                 threshold_nwords += 1
 


### PR DESCRIPTION
Otherwise, even with padding_factor specified, dictionary size remains non-multiple of padding factor. 