### PR TITLE
update sequence generator to support generation from a language model

### DIFF
--- a/fairseq/data/language_pair_dataset.py
+++ b/fairseq/data/language_pair_dataset.py
@@ -139,6 +139,10 @@ class LanguagePairDataset(FairseqDataset):
     def _get_max_positions(self, max_positions):
         if max_positions is None:
             return self.max_source_positions, self.max_target_positions
+        # If max_position is not a sequence (possibly from a monolingual model)
+        # then use the same upper bound for source & target
+        if not hasattr(max_positions, '__len__'):
+            max_positions = (max_positions, max_positions)
         assert len(max_positions) == 2
         max_src_pos, max_tgt_pos = max_positions
         return min(self.max_source_positions, max_src_pos), min(self.max_target_positions, max_tgt_pos)


### PR DESCRIPTION
This is a simple update for the `sequence_generator.py` script to support generation from a language model trained on the target vocabulary. Changes include:

1) Clone `max_positions` for source / target if it's set by a monolingual  LM;
2) Set the encoder output dictionary to None when using LM;
3) Check for None values of encoder output dictionary when calling `reorder_encoder_out`
4) Assert targets are given for adaptive softmax only at training time;
5) Copy attention values only if provided by the decoder model;
6) Squeeze the `probs` tensor instead of `decoder_out` as the adaptive softmax probability function expects 3D inputs.

This is a follow up on the issues: #213 and #212. I'm basically replicating the LM results from the hierarchical story generation paper (https://arxiv.org/abs/1805.04833), but I can't find the LM generation code in the repo. I'd appreciate if @huihuifan can take a look at this, in case it's a replicated or redundant pull request. 
