### PR TITLE
Correct path in the pre-processing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ To pre-process and binarize the IWSLT dataset:
 $ cd examples/translation/
 $ bash prepare-iwslt14.sh
 $ cd ../..
-$ TEXT=data/iwslt14.tokenized.de-en
+$ TEXT=examples/translation/iwslt14.tokenized.de-en
 $ python preprocess.py --source-lang de --target-lang en \
   --trainpref $TEXT/train --validpref $TEXT/valid --testpref $TEXT/test \
   --destdir data-bin/iwslt14.tokenized.de-en


### PR DESCRIPTION
Initially it's pointing to some arbitrary `/data/iwslt14.tokenized.de-en`, but given the steps above to cd `examples/translation` and then `cd ../..`, the appropriate path that contains the `iwslt14.tokenized.de-en` is `examples/translation/iwslt14.tokenized.de-en`