### PR TITLE
fix make_positions() typo

### DIFF
--- a/fairseq/utils.py
+++ b/fairseq/utils.py
@@ -312,7 +312,7 @@ def make_positions(tensor, padding_idx, left_pad, onnx_trace=False):
         positions = range_buf.expand_as(tensor)
         if left_pad:
             positions = positions - mask.size(1) + mask.long().sum(dim=1).unsqueeze(1)
-        return positions * mask.long() + positions * (1 - mask.long())
+        return positions * mask.long() + padding_idx * (1 - mask.long())
 
     max_pos = padding_idx + 1 + tensor.size(1)
     if not hasattr(make_positions, 'range_buf'):


### PR DESCRIPTION
Summary: This code should actually be keeping the padded positions as `padding_idx` (though note that this is on the ONNX export path, and it has no effect in the most common case when using the exported network to do un-batched inference).

Differential Revision: D10431872
