### PR TITLE
Expose BacktranslationDataset from fairseq.data

### DIFF
--- a/fairseq/data/__init__.py
+++ b/fairseq/data/__init__.py
@@ -10,6 +10,7 @@ from .fairseq_dataset import FairseqDataset
 from .concat_dataset import ConcatDataset
 from .indexed_dataset import IndexedDataset, IndexedCachedDataset, IndexedInMemoryDataset, IndexedRawTextDataset
 from .append_eos_dataset import AppendEosDataset
+from .backtranslation_dataset import BacktranslationDataset
 from .language_pair_dataset import LanguagePairDataset
 from .monolingual_dataset import MonolingualDataset
 from .round_robin_zip_datasets import RoundRobinZipDatasets
@@ -39,4 +40,5 @@ __all__ = [
     'RoundRobinZipDatasets',
     'ShardedIterator',
     'TokenBlockDataset',
+    'BacktranslationDataset',
 ]


### PR DESCRIPTION
Summary: BacktranslationDataset was introduced recently but was not exposed as part of the fairseq.data module

Reviewed By: liezl200

Differential Revision: D10412717
