### PR TITLE
Semi supervised task setup, dataset loading and model building

### DIFF
--- a/fairseq/data/__init__.py
+++ b/fairseq/data/__init__.py
@@ -10,6 +10,7 @@ from .fairseq_dataset import FairseqDataset
 from .concat_dataset import ConcatDataset
 from .indexed_dataset import IndexedDataset, IndexedCachedDataset, IndexedInMemoryDataset, IndexedRawTextDataset
 from .append_eos_dataset import AppendEosDataset
+from .backtranslation_dataset import BacktranslationDataset
 from .language_pair_dataset import LanguagePairDataset
 from .monolingual_dataset import MonolingualDataset
 from .round_robin_zip_datasets import RoundRobinZipDatasets
@@ -39,4 +40,5 @@ __all__ = [
     'RoundRobinZipDatasets',
     'ShardedIterator',
     'TokenBlockDataset',
+    'BacktranslationDataset',
 ]

--- a/fairseq/data/backtranslation_dataset.py
+++ b/fairseq/data/backtranslation_dataset.py
@@ -55,7 +55,7 @@ class BacktranslationDataset(FairseqDataset):
         """
         self.tgt_dataset = language_pair_dataset.LanguagePairDataset(
             src=tgt_dataset,
-            src_sizes=None,
+            src_sizes=tgt_dataset.sizes,
             src_dict=tgt_dict,
             tgt=None,
             tgt_sizes=None,
@@ -141,19 +141,19 @@ class BacktranslationDataset(FairseqDataset):
 
     def get_dummy_batch(self, num_tokens, max_positions):
         """ Just use the tgt dataset get_dummy_batch """
-        self.tgt_dataset.get_dummy_batch(num_tokens, max_positions)
+        return self.tgt_dataset.get_dummy_batch(num_tokens, max_positions)
 
     def num_tokens(self, index):
         """ Just use the tgt dataset num_tokens """
-        self.tgt_dataset.num_tokens(index)
+        return self.tgt_dataset.num_tokens(index)
 
     def ordered_indices(self):
         """ Just use the tgt dataset ordered_indices """
-        self.tgt_dataset.ordered_indices
+        return self.tgt_dataset.ordered_indices()
 
     def valid_size(self, index, max_positions):
         """ Just use the tgt dataset size """
-        self.tgt_dataset.valid_size(index, max_positions)
+        return self.tgt_dataset.valid_size(index, max_positions)
 
     def _generate_hypotheses(self, sample):
         """
@@ -171,3 +171,11 @@ class BacktranslationDataset(FairseqDataset):
             ),
         )
         return hypos
+
+    def size(self, index):
+        """Return an example's size as a float or tuple. This value is used when
+        filtering a dataset with ``--max-positions``.
+        Here, we return src dataset size as tgt dataset size as an approximation.
+        We do not know src size until we backtranslate and generate src sentences.
+        """
+        return (self.tgt_dataset.size(index), self.tgt_dataset.size(index))

--- a/fairseq/data/backtranslation_dataset.py
+++ b/fairseq/data/backtranslation_dataset.py
@@ -8,6 +8,7 @@
 import torch
 
 from fairseq import sequence_generator
+from fairseq import utils
 
 from . import FairseqDataset, language_pair_dataset
 
@@ -111,7 +112,7 @@ class BacktranslationDataset(FairseqDataset):
             # have an EOS appended to the end of each sentence.
             original_tgt = input_sample["source"]
             if original_tgt[-1] != eos:
-                original_tgt = torch.cat([original_tgt, torch.LongTensor(eos)])
+                original_tgt = torch.cat([original_tgt, torch.LongTensor([eos])])
 
             # The generated source dialect backtranslation will have an EOS.
             # If we want our parallel data source to not have an EOS, we will
@@ -128,8 +129,8 @@ class BacktranslationDataset(FairseqDataset):
             generated_samples.append(
                 {
                     "id": input_sample["id"],
-                    "source": generated_source,
-                    "target": original_tgt,
+                    "source": generated_source.cpu(),
+                    "target": original_tgt.cpu(),
                 }
             )
 
@@ -161,8 +162,12 @@ class BacktranslationDataset(FairseqDataset):
         sample. Note in this case, sample["target"] is None, and
         sample["net_input"]["src_tokens"] is really in tgt language.
         """
+        if torch.cuda.is_available():
+            s = utils.move_to_cuda(sample)
+        else:
+            s = sample
         self.backtranslation_generator.cuda()
-        input = sample["net_input"]
+        input = s["net_input"]
         srclen = input["src_tokens"].size(1)
         hypos = self.backtranslation_generator.generate(
             input,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -121,6 +121,7 @@ class TestDataset(torch.utils.data.Dataset):
     def __init__(self, data):
         super().__init__()
         self.data = data
+        self.sizes = None
 
     def __getitem__(self, index):
         return self.data[index]


### PR DESCRIPTION
Summary:
This code is heavily inspired (aka copied in parts) from @[139800366:Myle Ott]'s multilingual transformers implementation in [fairseq's PR #385](https://github.com/fairinternal/fairseq-py/pull/385/commits/18fa6e154781cf0c4b1596429dba7e753a545069). I am using pytorch_translate repo as a test bed to play around with the implementation before submitting a clean PR to fairseq.

The setup uses a new PytorchTranslateSemiSupervised task introduced in D10228123. The basic idea is to use FairseqMultiModel in conjunction with RoundRobinZipDataset to train 4 "language pairs":
1) source-target with LanguagePairDataset
2) target-source with reverse LanguagePairDataset
3) source-target_mono with BacktranslationDataset
4) target-source_mono with BacktranslationDataset

1 and 3, and 2 and 4 use the same models.

This is not multilingual yet, in that only one source_lang and one target_lang can be provided. However, this can easily be converted to multilingual semi supervised training by removing the dependency on source_lang and target_lang to prepare lang_pairs.

In the next diffs, we could consider adding support for:
Char source model
Weighted dataset
Multilingual multi_model

Reviewed By: liezl200

Differential Revision: D10318226
