### PR TITLE
Fix "ignore-case" behavior

### DIFF
--- a/score.py
+++ b/score.py
@@ -44,7 +44,8 @@ def main():
         for line in fd.readlines():
             if args.ignore_case:
                 yield line.lower()
-            yield line
+            else:     
+                yield line
 
     def score(fdsys):
         with open(args.ref) as fdref:


### PR DESCRIPTION
Currently, if `ignore-case` is set, the same line will be yielded twice - once as lower-cased version, once as original version, leading to lower than expected uncased scores.