### PR TITLE
Fix backtranslation dataset on IndexedCachedDataset 

### DIFF
--- a/fairseq/data/backtranslation_dataset.py
+++ b/fairseq/data/backtranslation_dataset.py
@@ -166,3 +166,11 @@ class BacktranslationDataset(FairseqDataset):
         """
         tgt_size = self.tgt_dataset.size(index)[0]
         return (tgt_size, tgt_size)
+    
+    @property
+    def supports_prefetch(self):
+        return self.tgt_dataset.supports_prefetch()
+
+    def prefetch(self, indices):
+        return self.tgt_dataset.prefetch(indices)
+


### PR DESCRIPTION
BacktranslationDataset would throw an error when the underlying dataset was an IndexedCachedDataset because prefetching was not handled correctly. This fixes the error.