### PR TITLE
Fixed wrong help message shown on '--help'

### DIFF
--- a/fairseq/options.py
+++ b/fairseq/options.py
@@ -124,7 +124,7 @@ def parse_args_and_arch(parser, input_args=None, parse_known=False):
 def get_parser(desc, default_task='translation'):
     # Before creating the true parser, we need to import optional user module
     # in order to eagerly import custom tasks, optimizers, architectures, etc.
-    usr_parser = argparse.ArgumentParser()
+    usr_parser = argparse.ArgumentParser(add_help=False)
     usr_parser.add_argument('--user-dir', default=None)
     usr_args, _ = usr_parser.parse_known_args()
 


### PR DESCRIPTION
Correct help message was obfuscated by the transient `ArgumentParser` used only for eagerly read `--user-dir` flag.

To reproduce just try:
```bash
python3 train.py --help
```