### PR TITLE
Look for bytecode(.pyc) files when importing modules

### DIFF
--- a/fairseq/criterions/__init__.py
+++ b/fairseq/criterions/__init__.py
@@ -40,6 +40,6 @@ def register_criterion(name):
 
 # automatically import any Python files in the criterions/ directory
 for file in os.listdir(os.path.dirname(__file__)):
-    if file.endswith('.py') and not file.startswith('_'):
+    if '.py' in file and not file.startswith('_'):
         module = file[:file.find('.py')]
         importlib.import_module('fairseq.criterions.' + module)

--- a/fairseq/models/__init__.py
+++ b/fairseq/models/__init__.py
@@ -105,7 +105,7 @@ def register_model_architecture(model_name, arch_name):
 
 # automatically import any Python files in the models/ directory
 for file in os.listdir(os.path.dirname(__file__)):
-    if file.endswith('.py') and not file.startswith('_'):
+    if '.py' in file and not file.startswith('_'):
         model_name = file[:file.find('.py')]
         module = importlib.import_module('fairseq.models.' + model_name)
 

--- a/fairseq/optim/__init__.py
+++ b/fairseq/optim/__init__.py
@@ -42,6 +42,6 @@ def register_optimizer(name):
 
 # automatically import any Python files in the optim/ directory
 for file in os.listdir(os.path.dirname(__file__)):
-    if file.endswith('.py') and not file.startswith('_'):
+    if '.py' in file and not file.startswith('_'):
         module = file[:file.find('.py')]
         importlib.import_module('fairseq.optim.' + module)

--- a/fairseq/optim/lr_scheduler/__init__.py
+++ b/fairseq/optim/lr_scheduler/__init__.py
@@ -34,6 +34,6 @@ def register_lr_scheduler(name):
 
 # automatically import any Python files in the optim/lr_scheduler/ directory
 for file in os.listdir(os.path.dirname(__file__)):
-    if file.endswith('.py') and not file.startswith('_'):
+    if '.py' in file and not file.startswith('_'):
         module = file[:file.find('.py')]
         importlib.import_module('fairseq.optim.lr_scheduler.' + module)

--- a/fairseq/tasks/__init__.py
+++ b/fairseq/tasks/__init__.py
@@ -57,7 +57,7 @@ def register_task(name):
 
 # automatically import any Python files in the tasks/ directory
 for file in os.listdir(os.path.dirname(__file__)):
-    if file.endswith('.py') and not file.startswith('_'):
+    if '.py' and not file.startswith('_'):
         task_name = file[:file.find('.py')]
         importlib.import_module('fairseq.tasks.' + task_name)
 


### PR DESCRIPTION
Summary:
We currently have 47 broken tests in pytorch_translate (https://fburl.com/tests/0riyt9ly) because when we run tests in mode/opt, machine only sees compiled files with *.pyc extension instead of original *.py files.

Therefore, all of these imports are failing with "key not found" errors (https://our.intern.facebook.com/intern/tests/details/562949963428218/debug/1561945).

Therefore, changing the way we are finding files, so that it includes compiled python files as well. This was the least intrusive way of solving this issue, let me know if you have other ideas.

Differential Revision: D13969981
