### PR TITLE
Try to access sys.stdin.fileno() only at runtime and not during import

### DIFF
--- a/fairseq/pdb.py
+++ b/fairseq/pdb.py
@@ -16,6 +16,10 @@ __all__ = ['set_trace']
 
 _stdin = [None]
 _stdin_lock = multiprocessing.Lock()
+try:
+    _stdin_fd = sys.stdin.fileno()
+except Exception:
+    _stdin_fd = None
 
 
 class MultiprocessingPdb(pdb.Pdb):
@@ -31,9 +35,10 @@ class MultiprocessingPdb(pdb.Pdb):
         stdin_bak = sys.stdin
         with _stdin_lock:
             try:
-                if not _stdin[0]:
-                    _stdin[0] = os.fdopen(stdin_bak.fileno())
-                sys.stdin = _stdin[0]
+                if _stdin_fd is not None:
+                    if not _stdin[0]:
+                        _stdin[0] = os.fdopen(_stdin_fd)
+                    sys.stdin = _stdin[0]
                 self.cmdloop()
             finally:
                 sys.stdin = stdin_bak

--- a/fairseq/pdb.py
+++ b/fairseq/pdb.py
@@ -14,7 +14,6 @@ import sys
 __all__ = ['set_trace']
 
 
-_stdin_fd = sys.stdin.fileno()
 _stdin = [None]
 _stdin_lock = multiprocessing.Lock()
 
@@ -33,7 +32,7 @@ class MultiprocessingPdb(pdb.Pdb):
         with _stdin_lock:
             try:
                 if not _stdin[0]:
-                    _stdin[0] = os.fdopen(_stdin_fd)
+                    _stdin[0] = os.fdopen(stdin_bak.fileno())
                 sys.stdin = _stdin[0]
                 self.cmdloop()
             finally:


### PR DESCRIPTION
Accessing sys.stdin.fileno() raises an error in multiple contexts
(pytest, joblib, jupyter...).
Thus accessing it at the top level of the file can cause other scripts
to crash when they import fairseq.
This is why it is moved inside the method of MultiprocessingPdb to only
be accessed at runtime if needed.

See  Issue #517