### PR TITLE
Minor fix for  multilingual example shell command

### DIFF
--- a/examples/translation/README.md
+++ b/examples/translation/README.md
@@ -207,10 +207,10 @@ $ CUDA_VISIBLE_DEVICES=0 fairseq-train data-bin/iwslt17.de_fr.en.bpe16k/ \
   --task multilingual_translation --lang-pairs de-en,fr-en \
   --arch multilingual_transformer_iwslt_de_en \
   --share-decoders --share-decoder-input-output-embed \
-  --optimizer adam --adam-betas '(0.9, 0.98)' 
+  --optimizer adam --adam-betas '(0.9, 0.98)' \
   --lr 0.0005 --lr-scheduler inverse_sqrt --min-lr '1e-09' \
   --warmup-updates 4000 --warmup-init-lr '1e-07' \
-  --label-smoothing 0.1 --criterion label_smoothed_cross_entropy
+  --label-smoothing 0.1 --criterion label_smoothed_cross_entropy \
   --dropout 0.3 --weight-decay 0.0001 \
   --save-dir checkpoints/multilingual_transformer \
   --max-tokens 4000 \

--- a/examples/translation/prepare-iwslt17-multilingual.sh
+++ b/examples/translation/prepare-iwslt17-multilingual.sh
@@ -114,13 +114,13 @@ for SRC in "${SRCS[@]}"; do
         python "$SPM_ENCODE" \
             --model "$DATA/sentencepiece.bpe.model" \
             --output_format=piece \
-            --inputs "$DATA/train.${SRC}-${TGT}.${SRC} $DATA/train.${SRC}-${TGT}.${TGT}" \
-            --outputs "$DATA/train.bpe.${SRC}-${TGT}.${SRC} $DATA/train.bpe.${SRC}-${TGT}.${TGT}" \
+            --inputs $DATA/train.${SRC}-${TGT}.${SRC} $DATA/train.${SRC}-${TGT}.${TGT} \
+            --outputs $DATA/train.bpe.${SRC}-${TGT}.${SRC} $DATA/train.bpe.${SRC}-${TGT}.${TGT} \
             --min-len $TRAIN_MINLEN --max-len $TRAIN_MAXLEN
         python "$SPM_ENCODE" \
             --model "$DATA/sentencepiece.bpe.model" \
             --output_format=piece \
-            --inputs "$DATA/valid.${SRC}-${TGT}.${SRC} $DATA/valid.${SRC}-${TGT}.${TGT}" \
-            --outputs "$DATA/valid.bpe.${SRC}-${TGT}.${SRC} $DATA/valid.bpe.${SRC}-${TGT}.${TGT}"
+            --inputs $DATA/valid.${SRC}-${TGT}.${SRC} $DATA/valid.${SRC}-${TGT}.${TGT} \
+            --outputs $DATA/valid.bpe.${SRC}-${TGT}.${SRC} $DATA/valid.bpe.${SRC}-${TGT}.${TGT}
     done
 done


### PR DESCRIPTION
Add `\` to fix for the shell command.