### PR TITLE
Fix save_dir creation while training on multiple nodes

### DIFF
--- a/fairseq/modules/transformer_sentence_encoder.py
+++ b/fairseq/modules/transformer_sentence_encoder.py
@@ -106,7 +106,7 @@ class TransformerSentenceEncoder(nn.Module):
         self.use_position_embeddings = use_position_embeddings
         self.apply_bert_init = apply_bert_init
 
-        self.token_embeddings = nn.Embedding(
+        self.embed_tokens = nn.Embedding(
             self.vocab_size, self.embedding_dim, self.padding_idx
         )
 
@@ -116,7 +116,7 @@ class TransformerSentenceEncoder(nn.Module):
             else None
         )
 
-        self.position_embeddings = (
+        self.embed_positions = (
             PositionalEmbedding(
                 self.max_seq_len,
                 self.embedding_dim,
@@ -161,8 +161,8 @@ class TransformerSentenceEncoder(nn.Module):
 
         # embed positions
         positions = (
-            self.position_embeddings(tokens)
-            if self.position_embeddings is not None else None
+            self.embed_positions(tokens)
+            if self.embed_positions is not None else None
         )
 
         # embed segments
@@ -172,7 +172,7 @@ class TransformerSentenceEncoder(nn.Module):
             else None
         )
 
-        x = self.token_embeddings(tokens)
+        x = self.embed_tokens(tokens)
         if positions is not None:
             x += positions
         if segments is not None:

--- a/fairseq/modules/transformer_sentence_encoder_layer.py
+++ b/fairseq/modules/transformer_sentence_encoder_layer.py
@@ -51,7 +51,7 @@ class TransformerSentenceEncoderLayer(nn.Module):
 
         # Initialize blocks
         self.activation_fn = gelu if use_gelu else F.relu
-        self.self_attention = MultiheadAttention(
+        self.self_attn = MultiheadAttention(
             self.embedding_dim, num_attention_heads, dropout=attention_dropout
         )
 
@@ -97,7 +97,7 @@ class TransformerSentenceEncoderLayer(nn.Module):
 
         residual = x
         x = self._maybe_layer_norm(self.self_attn_layer_norm, x, before=True)
-        x, attn = self.self_attention(
+        x, attn = self.self_attn(
             query=x,
             key=x,
             value=x,

--- a/train.py
+++ b/train.py
@@ -342,7 +342,11 @@ def save_checkpoint(args, trainer, epoch_itr, val_loss):
 
 def load_checkpoint(args, trainer, epoch_itr):
     """Load a checkpoint and replay dataloader to match."""
-    os.makedirs(args.save_dir, exist_ok=True)
+
+    # Only rank 0 should attempt to create the required dir
+    if args.distributed_rank == 0:
+        os.makedirs(args.save_dir, exist_ok=True)
+
     if os.path.isabs(args.restore_file):
         checkpoint_path = args.restore_file
     else:


### PR DESCRIPTION
Summary: While training a model on multiple GPUs, the current fairseq train workflow fails while creating the directory from which to load a checkpoint. This seems to be happening because multiple nodes attempt to create the same directory thus causing some weird interaction with os.makedirs option "exist_ok=True". Fixing this by making sure only rank 0 creates this directory.

Reviewed By: jingfeidu

Differential Revision: D14841304
