### PR TITLE
Fix sacrebleu

### DIFF
--- a/fairseq/bleu.py
+++ b/fairseq/bleu.py
@@ -52,7 +52,7 @@ class SacrebleuScorer(object):
         self.sys.append(pred)
 
     def score(self, order=4):
-        return self.result_string(order).bleu
+        return self.result_string(order).score
 
     def result_string(self, order=4):
         if order != 4:


### PR DESCRIPTION
Summary:
sacrebleu scorer has stopped working in pytorch_translate (maybe
fairseq too) probably due to  a recent api change.

Differential Revision: D14792797
