### PR TITLE
reduce memory footprint for average_checkpoints

### DIFF
--- a/scripts/average_checkpoints.py
+++ b/scripts/average_checkpoints.py
@@ -21,6 +21,8 @@ def average_checkpoints(inputs):
     params_dict = collections.OrderedDict()
     params_keys = None
     new_state = None
+    num_models = len(inputs)
+
     for f in inputs:
         state = torch.load(
             f,
@@ -44,20 +46,18 @@ def average_checkpoints(inputs):
             )
 
         for k in params_keys:
-            if k not in params_dict:
-                params_dict[k] = []
             p = model_params[k]
             if isinstance(p, torch.HalfTensor):
                 p = p.float()
-            params_dict[k].append(p)
+            if k not in params_dict:
+                params_dict[k] = p
+            else:
+                params_dict[k] += p
 
     averaged_params = collections.OrderedDict()
     # v should be a list of torch Tensor.
     for k, v in params_dict.items():
-        summed_v = None
-        for x in v:
-            summed_v = summed_v + x if summed_v is not None else x
-        averaged_params[k] = summed_v / len(v)
+        averaged_params[k] = v / num_models
     new_state['model'] = averaged_params
     return new_state
 


### PR DESCRIPTION
Summary:
the current implementation of average_checkpoints requires loading all
the model parameters into memory and then do the averaging. To average large
models (e.g., transformer) over a large number of checkpoints (e.g., >50),
it may require over 100GB memory.

Loading all the parameters is not necessary, as we know the number of models in advance.

Differential Revision: D15027513

