### PR TITLE
Add gelu and gelu_fast as possible activation functions

### DIFF
--- a/fairseq/models/masked_lm.py
+++ b/fairseq/models/masked_lm.py
@@ -136,7 +136,7 @@ class MaskedLMEncoder(FairseqEncoder):
         )
         encoder_normalize_before = getattr(args, 'encoder_normalize_before', False)
         use_bert_layer_norm = getattr(args, 'bert_layer_norm', False)
-        use_gelu = getattr(args, 'use_gelu', False)
+        use_gelu = getattr(args, 'gelu', False)
         apply_bert_init = getattr(args, 'apply_bert_init', False)
 
         self.sentence_encoder = TransformerSentenceEncoder(

--- a/fairseq/modules/__init__.py
+++ b/fairseq/modules/__init__.py
@@ -13,6 +13,7 @@ from .character_token_embedder import CharacterTokenEmbedder
 from .conv_tbc import ConvTBC
 from .downsampled_multihead_attention import DownsampledMultiHeadAttention
 from .dynamic_convolution import DynamicConv1dTBC
+from .gelu import gelu, gelu_fast
 from .grad_multiply import GradMultiply
 from .highway import Highway
 from .layer_norm import LayerNorm
@@ -37,6 +38,8 @@ __all__ = [
     'ConvTBC',
     'DownsampledMultiHeadAttention',
     'DynamicConv1dTBC',
+    'gelu',
+    'gelu_fast',
     'GradMultiply',
     'Highway',
     'LayerNorm',

--- a/fairseq/modules/gelu.py
+++ b/fairseq/modules/gelu.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the LICENSE file in
+# the root directory of this source tree. An additional grant of patent rights
+# can be found in the PATENTS file in the same directory.
+
+import math
+
+import torch
+
+
+"""
+See "Gaussian Error Linear Units (GELUs)" by Dan Hendrycks and Kevin Gimpel with
+the corresponding GitHub repo: https://github.com/hendrycks/GELUs
+"""
+
+
+def gelu_fast(x):
+    if not hasattr(gelu_fast, "_a"):
+        gelu_fast._a = math.sqrt(2 / math.pi)
+    return 0.5 * x * (1 + torch.tanh(gelu_fast._a * (x + 0.044715 * torch.pow(x, 3))))
+
+
+def gelu(x: torch.Tensor) -> torch.Tensor:
+    return x * 0.5 * (1.0 + torch.erf(x / math.sqrt(2.0)))

--- a/fairseq/modules/transformer_sentence_encoder_layer.py
+++ b/fairseq/modules/transformer_sentence_encoder_layer.py
@@ -10,14 +10,7 @@ import math
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from fairseq.modules import MultiheadAttention, BertLayerNorm
-
-
-def gelu(x: torch.Tensor) -> torch.Tensor:
-    """
-    Implementation of the gelu activation function.
-    """
-    return x * 0.5 * (1.0 + torch.erf(x / math.sqrt(2.0)))
+from fairseq.modules import gelu, MultiheadAttention, BertLayerNorm
 
 
 class TransformerSentenceEncoderLayer(nn.Module):

--- a/fairseq/utils.py
+++ b/fairseq/utils.py
@@ -6,6 +6,7 @@
 # can be found in the PATENTS file in the same directory.
 
 from collections import defaultdict, OrderedDict
+from typing import Callable
 import copy
 import importlib.util
 import logging
@@ -18,6 +19,8 @@ import warnings
 import torch
 import torch.nn.functional as F
 from torch.serialization import default_restore_location
+
+from fairseq.modules import gelu, gelu_fast
 
 
 def torch_persistent_save(*args, **kwargs):
@@ -462,3 +465,15 @@ def log_softmax(x, dim, onnx_trace=False):
 def deprecation_warning(message, stacklevel=3):
     # don't use DeprecationWarning, since it's ignored by default
     warnings.warn(message, stacklevel=stacklevel)
+
+
+def get_activation_fn(activation: str) -> Callable:
+    """ Returns the activation function corresponding to `activation` """
+    if activation == 'relu':
+        return F.relu
+    elif activation == 'gelu':
+        return gelu
+    elif activation == 'gelu_fast':
+        return gelu_fast
+    else:
+        raise RuntimeError(f"--activation-fn {activation} not supported")


### PR DESCRIPTION
Summary:
After this diff, you can train a transformer model with --activation-fn 'relu', 'gelu', or 'gelu_fast'

gelu_fast is the default implementation in https://github.com/hendrycks/GELUs/blob/master/mnist_fcn.py#L72-L77
gelu is the alternate implementation in https://github.com/hendrycks/GELUs/blob/master/mnist_fcn.py#L72-L77 and the default implementation in https://github.com/facebookresearch/XLM

Differential Revision: D14966006

