### PR TITLE
Passing kwargs in setup_task in fairseq_task

### DIFF
--- a/fairseq/tasks/__init__.py
+++ b/fairseq/tasks/__init__.py
@@ -15,8 +15,8 @@ TASK_REGISTRY = {}
 TASK_CLASS_NAMES = set()
 
 
-def setup_task(args):
-    return TASK_REGISTRY[args.task].setup_task(args)
+def setup_task(args, **kwargs):
+    return TASK_REGISTRY[args.task].setup_task(args, **kwargs)
 
 
 def register_task(name):

--- a/fairseq/tasks/fairseq_task.py
+++ b/fairseq/tasks/fairseq_task.py
@@ -62,7 +62,7 @@ class FairseqTask(object):
         Args:
             args (argparse.Namespace): parsed command-line arguments
         """
-        return cls(args)
+        return cls(args, **kwargs)
 
     def load_dataset(self, split, combine=False, **kwargs):
         """Load a given dataset split.


### PR DESCRIPTION
Summary: Pytorch-translate task needs to use extra arguments (such as vocabulary objects). By passing kwargs, we are able to have the ability to have extra arguments in setup_task

Differential Revision: D15086810

