### PR TITLE
Fix upgrade_state_dict for XLM Transformer sentence encoder

### DIFF
--- a/fairseq/models/masked_lm.py
+++ b/fairseq/models/masked_lm.py
@@ -231,11 +231,11 @@ class MaskedLMEncoder(FairseqEncoder):
 
     def upgrade_state_dict_named(self, state_dict, name):
         if isinstance(
-                self.sentence_encoder.position_embeddings,
+                self.sentence_encoder.embed_positions,
                 SinusoidalPositionalEmbedding
         ):
             state_dict[
-                name + '.sentence_encoder.position_embeddings._float_tensor'
+                name + '.sentence_encoder.embed_positions._float_tensor'
             ] = torch.FloatTensor(1)
         if not self.load_softmax:
             for k in list(state_dict.keys()):


### PR DESCRIPTION
Summary:
Some embedding names were renamed but this one was missed

So far I've only seen this affect our runs during continuing training. If you encountered any errors when continuing training from an XLM save_dir, rebasing past this diff (or patching this and canarying) should fix the problem

Reviewed By: pipibjc

Differential Revision: D15137463

