### PR TITLE
Add call to barrier() immediately after distributed_init

### DIFF
--- a/fairseq/distributed_utils.py
+++ b/fairseq/distributed_utils.py
@@ -67,6 +67,7 @@ def distributed_init(args):
             world_size=args.distributed_world_size,
             rank=args.distributed_rank,
         )
+        dist.barrier()
 
         suppress_output(is_master(args))
 


### PR DESCRIPTION
See https://github.com/facebookresearch/maskrcnn-benchmark/issues/172