### PR TITLE
Make Fairseq compatible with pre-computed position tensors

### DIFF
--- a/fairseq/modules/learned_positional_embedding.py
+++ b/fairseq/modules/learned_positional_embedding.py
@@ -11,26 +11,41 @@ from fairseq import utils
 
 
 class LearnedPositionalEmbedding(nn.Embedding):
-    """This module learns positional embeddings up to a fixed maximum size.
-
-    Padding symbols are ignored.
+    """
+    This module learns positional embeddings up to a fixed maximum size.
+    Padding ids are ignored by either offsetting based on padding_idx
+    or by setting padding_idx to None and ensuring that the appropriate
+    position ids are passed to the forward function.
     """
 
-    def __init__(self, num_embeddings, embedding_dim, padding_idx):
+    def __init__(
+            self,
+            num_embeddings: int,
+            embedding_dim: int,
+            padding_idx: int,
+    ):
         super().__init__(num_embeddings, embedding_dim, padding_idx)
         self.onnx_trace = False
 
-    def forward(self, input, incremental_state=None):
+    def forward(self, input, incremental_state=None, positions=None):
         """Input is expected to be of size [bsz x seqlen]."""
-        if incremental_state is not None:
-            # positions is the same for every token when decoding a single step
-            positions = input.data.new(1, 1).fill_(self.padding_idx + input.size(1))
-        else:
-            positions = utils.make_positions(
-                input.data, self.padding_idx, onnx_trace=self.onnx_trace,
-            )
+        assert (
+            (positions is None) or (self.padding_idx is None)
+        ), "If positions is pre-computed then padding_idx should not be set."
+
+        if positions is None:
+            if incremental_state is not None:
+                # positions is the same for every token when decoding a single step
+                positions = input.data.new(1, 1).fill_(self.padding_idx + input.size(1))
+            else:
+                positions = utils.make_positions(
+                    input.data, self.padding_idx, onnx_trace=self.onnx_trace,
+                )
         return super().forward(positions)
 
     def max_positions(self):
         """Maximum number of supported positions."""
-        return self.num_embeddings - self.padding_idx - 1
+        if self.padding_idx is not None:
+            return self.num_embeddings - self.padding_idx - 1
+        else:
+            return self.num_embeddings

--- a/fairseq/modules/positional_embedding.py
+++ b/fairseq/modules/positional_embedding.py
@@ -11,13 +11,23 @@ from .learned_positional_embedding import LearnedPositionalEmbedding
 from .sinusoidal_positional_embedding import SinusoidalPositionalEmbedding
 
 
-def PositionalEmbedding(num_embeddings, embedding_dim, padding_idx, learned=False):
+def PositionalEmbedding(
+        num_embeddings: int,
+        embedding_dim: int,
+        padding_idx: int,
+        learned: bool = False,
+):
     if learned:
-        m = LearnedPositionalEmbedding(
-            num_embeddings + padding_idx + 1, embedding_dim, padding_idx,
-        )
+        # if padding_idx is specified then offset the embedding ids by
+        # this index and adjust num_embeddings appropriately
+        # TODO: The right place for this offset would be inside
+        # LearnedPositionalEmbedding. Move this there for a cleaner implementation.
+        if padding_idx is not None:
+            num_embeddings = num_embeddings + padding_idx + 1
+        m = LearnedPositionalEmbedding(num_embeddings, embedding_dim, padding_idx)
         nn.init.normal_(m.weight, mean=0, std=embedding_dim ** -0.5)
-        nn.init.constant_(m.weight[padding_idx], 0)
+        if padding_idx is not None:
+            nn.init.constant_(m.weight[padding_idx], 0)
     else:
         m = SinusoidalPositionalEmbedding(
             embedding_dim, padding_idx, init_size=num_embeddings + padding_idx + 1,


### PR DESCRIPTION
Summary: Currently the LearnedPositionalEmbedding module computes the position tensor based on the input data. However this really doesnt work for XLM where we have different behavior based on the Masked LM and Translation LM. In this diff I keep the same default behavior for LearnedPositionalEmbedding as before but add the ability for these models to work with pre-computed position tensors.

Differential Revision: D15305474

