### PR TITLE
fixed bugs of masked_lm for fine-tuning

### DIFF
--- a/fairseq/models/masked_lm.py
+++ b/fairseq/models/masked_lm.py
@@ -159,6 +159,7 @@ class MaskedLMEncoder(FairseqEncoder):
         self.embed_out = None
         self.sentence_projection_layer = None
         self.sentence_out_dim = args.sentence_class_num
+        self.lm_output_learned_bias = None
 
         # Remove head is set to true during fine-tuning
         self.load_softmax = not getattr(args, 'remove_head', False)
@@ -252,7 +253,11 @@ class MaskedLMEncoder(FairseqEncoder):
             ] = torch.FloatTensor(1)
         if not self.load_softmax:
             for k in list(state_dict.keys()):
-                if "embed_out.weight" in k or "sentence_projection_layer.weight" in k:
+                if (
+                    "embed_out.weight" in k or
+                    "sentence_projection_layer.weight" in k or
+                    "lm_output_learned_bias" in k
+                ):
                     del state_dict[k]
         return state_dict
 


### PR DESCRIPTION
Summary:
After we added additional prediciton layers for language model predictions. The fine-tuning is broken because of 2 reasons.
1. checkpoint cannot be loaded since we didn't update state_dict names
2. lm_output_learned_bias is not initialize if load_softmax is false

Reviewed By: myleott

Differential Revision: D15377380

