### PR TITLE
Device error in SinusoidalPositionalEmbedding

### DIFF
--- a/fairseq/modules/sinusoidal_positional_embedding.py
+++ b/fairseq/modules/sinusoidal_positional_embedding.py
@@ -65,7 +65,7 @@ class SinusoidalPositionalEmbedding(nn.Module):
                 self.embedding_dim,
                 self.padding_idx,
             )
-        self.weights = self.weights.type_as(self._float_tensor)
+        self.weights = self.weights.to(self._float_tensor)
 
         if incremental_state is not None:
             # positions is the same for every token when decoding a single step
@@ -80,10 +80,10 @@ class SinusoidalPositionalEmbedding(nn.Module):
             embedding_shape = torch.cat((bsz.view(1), seq_len.view(1), torch.LongTensor([-1])))
             embeddings = torch.onnx.operators.reshape_from_tensor_shape(flat_embeddings, embedding_shape)
             return embeddings
-        print(f'{self.weights.device} is device of weights, '
-              f'{positions.device} is device of positions, '
-              f'{input.device} is device of input, '
-              f'{self._float_tensor.device} is device of _float_tensor')
+        # print(f'{self.weights.device} is device of weights, '
+        #       f'{positions.device} is device of positions, '
+        #       f'{input.device} is device of input, '
+        #       f'{self._float_tensor.device} is device of _float_tensor')
         return self.weights.index_select(0, positions.view(-1)).view(bsz, seq_len, -1).detach()
 
     def max_positions(self):

--- a/fairseq/modules/sinusoidal_positional_embedding.py
+++ b/fairseq/modules/sinusoidal_positional_embedding.py
@@ -80,10 +80,6 @@ class SinusoidalPositionalEmbedding(nn.Module):
             embedding_shape = torch.cat((bsz.view(1), seq_len.view(1), torch.LongTensor([-1])))
             embeddings = torch.onnx.operators.reshape_from_tensor_shape(flat_embeddings, embedding_shape)
             return embeddings
-        # print(f'{self.weights.device} is device of weights, '
-        #       f'{positions.device} is device of positions, '
-        #       f'{input.device} is device of input, '
-        #       f'{self._float_tensor.device} is device of _float_tensor')
         return self.weights.index_select(0, positions.view(-1)).view(bsz, seq_len, -1).detach()
 
     def max_positions(self):

--- a/fairseq/modules/sinusoidal_positional_embedding.py
+++ b/fairseq/modules/sinusoidal_positional_embedding.py
@@ -82,7 +82,8 @@ class SinusoidalPositionalEmbedding(nn.Module):
             return embeddings
         print(f'{self.weights.device} is device of weights, '
               f'{positions.device} is device of positions, '
-              f'{input.device} is device of input')
+              f'{input.device} is device of input, '
+              f'{self._float_tensor.device} is device of _float_tensor')
         return self.weights.index_select(0, positions.view(-1)).view(bsz, seq_len, -1).detach()
 
     def max_positions(self):

--- a/fairseq/modules/sinusoidal_positional_embedding.py
+++ b/fairseq/modules/sinusoidal_positional_embedding.py
@@ -80,6 +80,9 @@ class SinusoidalPositionalEmbedding(nn.Module):
             embedding_shape = torch.cat((bsz.view(1), seq_len.view(1), torch.LongTensor([-1])))
             embeddings = torch.onnx.operators.reshape_from_tensor_shape(flat_embeddings, embedding_shape)
             return embeddings
+        print(f'{self.weights.device} is device of weights, '
+              f'{positions.device} is device of positions, '
+              f'{input.device} is device of input')
         return self.weights.index_select(0, positions.view(-1)).view(bsz, seq_len, -1).detach()
 
     def max_positions(self):


### PR DESCRIPTION
Not sure if i'm doing something wrong, but had a device error while trying to run sinusoid position embeddings on a non-0 GPU because the weight in `SinusoidalPositionalEmbedding` only copied type and not device.