### PR TITLE
Fix sizes in ConcatDataset

### DIFF
--- a/fairseq/data/concat_dataset.py
+++ b/fairseq/data/concat_dataset.py
@@ -64,9 +64,7 @@ class ConcatDataset(FairseqDataset):
 
     @property
     def sizes(self):
-        return np.concatenate(
-            [np.tile(ds.sizes, sr) for ds, sr in zip(self.datasets, self.sample_ratios)]
-        )
+        return [self.size(idx) for idx in range(len(self))]
 
     @property
     def supports_prefetch(self):


### PR DESCRIPTION
Summary:
There are 2 problems with old sizes() function.

1. It only supports sample ratios of type int

2. some datasets (e.g. LanguagePairDataset) don't have sizes()

Differential Revision: D15720559

