### PR TITLE
Features to ensemble models with weights and difference tasks(Translation and Language Modeling)

### DIFF
--- a/eval_lm.py
+++ b/eval_lm.py
@@ -152,6 +152,8 @@ def main(parsed_args):
                 hypo = hypos_i[0]
 
                 tokens = hypo['tokens']
+                if args.output_sent_score:
+                    print(f"{hypo['score'].item()}")
                 tgt_len = tokens.numel()
                 pos_scores = hypo['positional_scores'].float()
 

--- a/fairseq/options.py
+++ b/fairseq/options.py
@@ -370,12 +370,16 @@ def add_common_eval_args(group):
     group.add_argument('--ensemble-weights', metavar='EXPR', default=None,
                        help='weight(s) for ensemble, tuple expression, must '
                             'be set to the same size the as --path option')
+    group.add_argument('--with-ensemble-dir', action='store_true', default=False,
+                       help='override the model state args with current parsed attributes '
+                            'to re-setup a task, this makes it easy for ensemble when all '
+                            'models and data are in one directory')
     group.add_argument('--remove-bpe', nargs='?', const='@@ ', default=None,
                        help='remove BPE tokens before scoring (can be set to sentencepiece)')
     group.add_argument('--quiet', action='store_true',
                        help='only print final scores')
-    group.add_argument('--model-overrides', default="{}", type=str, metavar='DICT',
-                       help='a dictionary used to override model args at generation '
+    group.add_argument('--model-overrides', default="{}", type=str, metavar='DICT/LIST',
+                       help='a dictionary/list used to override model args at generation '
                             'that were used during model training')
     group.add_argument('--results-path', metavar='RESDIR', type=str, default=None,
                        help='path to save eval results (optional)"')

--- a/fairseq/options.py
+++ b/fairseq/options.py
@@ -365,6 +365,11 @@ def add_common_eval_args(group):
     # fmt: off
     group.add_argument('--path', metavar='FILE',
                        help='path(s) to model file(s), colon separated')
+    group.add_argument('--ensemble-method', choices=['logsumexp', 'sum'], default='logsumexp',
+                       help='log probabilities ensemble method')
+    group.add_argument('--ensemble-weights', metavar='EXPR', default=None,
+                       help='weight(s) for ensemble, tuple expression, must '
+                            'be set to the same size the as --path option')
     group.add_argument('--remove-bpe', nargs='?', const='@@ ', default=None,
                        help='remove BPE tokens before scoring (can be set to sentencepiece)')
     group.add_argument('--quiet', action='store_true',

--- a/fairseq/sequence_generator.py
+++ b/fairseq/sequence_generator.py
@@ -571,7 +571,7 @@ class EnsembleModel(torch.nn.Module):
     def forward_encoder(self, encoder_input):
         if not self.has_encoder():
             return None
-        return [model.encoder(**encoder_input) for model in self.models]
+        return [model.encoder(**encoder_input) if hasattr(model, 'encoder') else None for model in self.models]
 
     @torch.no_grad()
     def forward_decoder(self, tokens, encoder_outs, temperature=1.):
@@ -639,6 +639,7 @@ class EnsembleModel(torch.nn.Module):
             return
         return [
             model.encoder.reorder_encoder_out(encoder_out, new_order)
+            if hasattr(model, 'encoder') else None
             for model, encoder_out in zip(self.models, encoder_outs)
         ]
 

--- a/fairseq/tasks/fairseq_task.py
+++ b/fairseq/tasks/fairseq_task.py
@@ -206,6 +206,8 @@ class FairseqTask(object):
                 diverse_beam_strength=getattr(args, 'diverse_beam_strength', 0.5),
                 match_source_len=getattr(args, 'match_source_len', False),
                 no_repeat_ngram_size=getattr(args, 'no_repeat_ngram_size', 0),
+                ensemble_weights=args.ensemble_weights,
+                ensemble_method=args.ensemble_method
             )
 
     def train_step(self, sample, model, criterion, optimizer, ignore_grad=False):

--- a/fairseq/tasks/language_modeling.py
+++ b/fairseq/tasks/language_modeling.py
@@ -65,6 +65,7 @@ class LanguageModelingTask(FairseqTask):
                                  'tokens. If set to "complete", splits samples only at the end '
                                  'of sentence, but may include multiple sentences per sample. '
                                  'If set to "eos", includes only one sentence per sample.')
+        parser.add_argument('--output-sent-score', action='store_true')
         parser.add_argument('--tokens-per-sample', default=1024, type=int,
                             help='max number of tokens per sample for LM dataset')
         parser.add_argument('--lazy-load', action='store_true',

--- a/fairseq/utils.py
+++ b/fairseq/utils.py
@@ -254,6 +254,8 @@ def resolve_max_positions(*args):
 
     max_positions = None
     for arg in args:
+        if not isinstance(arg, tuple):
+            arg = (arg,)
         if max_positions is None:
             max_positions = arg
         elif arg is not None:

--- a/generate.py
+++ b/generate.py
@@ -49,6 +49,7 @@ def main(args):
         args.path.split(':'),
         arg_overrides=eval(args.model_overrides),
         task=task,
+        cmd_args=args if args.with_ensemble_dir else None,
     )
 
     # Optimize ensemble for generation

--- a/generate.py
+++ b/generate.py
@@ -17,6 +17,8 @@ from fairseq.meters import StopwatchMeter, TimeMeter
 
 def main(args):
     assert args.path is not None, '--path required for generation!'
+    if args.ensemble_weights is not None:
+        args.ensemble_weights = eval(args.ensemble_weights)
     assert not args.sampling or args.nbest == args.beam, \
         '--sampling requires --nbest to be equal to --beam'
     assert args.replace_unk is None or args.raw_text, \


### PR DESCRIPTION
- Add ensemble features (different from the builtin implementation): support to ensemble many encoder-decoder models with weights.
- Add support to ensemble two different task architecture tasks (Translation/LanguageModel Tasks).
- Add option to enable output scores evaluated by language model.

**If keep the origin cmd option, then generate.py just behave as what it does before.**

Description:
> We absorb in idea from this code gist: https://github.com/marian-nmt/marian/blob/2c164a4363fcd65db3b0c3ee13071583007b9209/src/translator/beam_search.h#L238, if the weights were set set properly, the ensembled would achieve better performance.

For ensemble same architecture models:
 - add --ensemble-method option to set ensemble method (sum/logexpsum)
 - add --ensemble-weights option to set ensemble weights of models

For different tasks (Translation/Language Modeling):
 - add --with-ensemble-dir option to support models/data in the same directory.
 - add list parse support for --model-overrides with different arch/model support (The ensemble of a Translation task model and a Language Modeling task is tested).

For Language modeling sentence score:
 - add --output-sent-score option to enable scores and can be separated with "grep ^-"

The detailed description is in the commit message (last three).