### PR TITLE
Added a comment to inform coders that pack_padded_sequence requires that padding must be on the right

### DIFF
--- a/fairseq/models/lstm.py
+++ b/fairseq/models/lstm.py
@@ -209,6 +209,7 @@ class LSTMEncoder(FairseqEncoder):
 
     def forward(self, src_tokens, src_lengths):
         if self.left_pad:
+            # nn.utils.rnn.pack_padded_sequence requires right-padding;
             # convert left-padding to right-padding
             src_tokens = utils.convert_padding_direction(
                 src_tokens,


### PR DESCRIPTION
The PyTorch document on pack_padded_sequence has no information regarding a requirement that padding must be on the right. Therefore, this information is added as a comment on Line 212 of [https://github.com/vineetk1/fairseq/blob/master/fairseq/models/lstm.py](url)