### PR TITLE
Add specific compile flags for macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,14 +16,17 @@ if sys.version_info < (3,):
 with open('README.md') as f:
     readme = f.read()
 
-
+if sys.platform == 'darwin':
+    extra_compile_args = ['-stdlib=libc++']
+else:
+    extra_compile_args = ['-std=c++11']
 bleu = Extension(
     'fairseq.libbleu',
     sources=[
         'fairseq/clib/libbleu/libbleu.cpp',
         'fairseq/clib/libbleu/module.cpp',
     ],
-    extra_compile_args=['-std=c++11'],
+    extra_compile_args=extra_compile_args,
 )
 
 


### PR DESCRIPTION
Fairseq wouldn't install on macOS.
A workaround was found here: https://github.com/pytorch/fairseq/issues/289
This is now automatic in setup.py, maybe be there's a cleaner way to do it.

I checked that it compiles fine on Linux and macOS.