### PR TITLE
add __len__ for progress_bar

### DIFF
--- a/fairseq/progress_bar.py
+++ b/fairseq/progress_bar.py
@@ -80,6 +80,9 @@ class progress_bar(object):
         if prefix is not None:
             self.prefix += ' | {}'.format(prefix)
 
+    def __len__(self):
+        return len(self.iterable)
+
     def __enter__(self):
         return self
 


### PR DESCRIPTION
We need this so that `progress_bar`s work with pytorch/xla i.e. TPUs. See [here](https://github.com/pytorch/xla/blob/master/torch_xla_py/data_parallel.py#L130).