### PR TITLE
adding __getstate__ to fairseq_optimizer

### DIFF
--- a/fairseq/optim/fairseq_optimizer.py
+++ b/fairseq/optim/fairseq_optimizer.py
@@ -41,6 +41,9 @@ class FairseqOptimizer(object):
         """
         raise NotImplementedError
 
+    def __getstate__(self):
+        return self._optimizer.__getstate__()
+
     def get_lr(self):
         """Return the current learning rate."""
         return self.optimizer.param_groups[0]['lr']


### PR DESCRIPTION
self._optimizer has __getstate__
We need this so that fairseq_optimizer's work with pytorch/xla

```
% find . | xargs grep -s -i __getstate__
./third_party/tensorflow/tensorflow/python/util/deprecation_wrapper.py:  def __getstate__(self):
./torch_xla_py/xla_model.py:  for param_group in optimizer.__getstate__()['param_groups']:
```