### PR TITLE
Fewer torch.hub requirements

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -11,12 +11,8 @@ from fairseq.models import MODEL_REGISTRY
 
 
 dependencies = [
-    'fastBPE',
     'regex',
     'requests',
-    'sacremoses',
-    'sentencepiece',
-    'subword_nmt',
     'torch',
 ]
 


### PR DESCRIPTION
We will raise exceptions if these are needed and aren't available. Only keep minimum set of reqs