### PR TITLE
MacOS requires c++ flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ After PyTorch is installed, you can install fairseq with `pip`:
 ```
 pip install fairseq
 ```
-
+On MacOS,
+```
+CFLAGS="-stdlib=libc++" pip install fairseq
+```
 **Installing from source**
 
 To install fairseq from source and develop locally:


### PR DESCRIPTION
To install on MacOS, `-stdlib=libc++` needs to be specified.