### PR TITLE
fix string format to work in python 3.5

### DIFF
--- a/fairseq/data/subsample_dataset.py
+++ b/fairseq/data/subsample_dataset.py
@@ -17,7 +17,7 @@ class SubsampleDataset(BaseWrapperDataset):
             range(len(self.dataset)), self.actual_size, replace=False
         )
         print(
-            f"subsampled dataset from {len(self.dataset)} to {self.actual_size} (ratio={size_ratio})"
+            "subsampled dataset from {} to {} (ratio={})".format(len(self.dataset), self.actual_size, size_ratio)
         )
 
     def __getitem__(self, index):


### PR DESCRIPTION
change string fromat in fairseq/data/subsample_dataset.py#20