### PR TITLE
Minor update of README.md of language model example

### DIFF
--- a/examples/language_model/README.md
+++ b/examples/language_model/README.md
@@ -51,7 +51,7 @@ fairseq-preprocess \
     --only-source \
     --trainpref $TEXT/wiki.train.tokens \
     --validpref $TEXT/wiki.valid.tokens \
-    --testpref $TEXT/wiki.test.tokens \ 
+    --testpref $TEXT/wiki.test.tokens \
     --destdir data-bin/wikitext-103 \
     --workers 20
 ```


### PR DESCRIPTION
With this white space, the command might fail.
```
fairseq-preprocess: error: unrecognized arguments:
zsh: command not found: --destdir
```