### PR TITLE
Fix 'include' in the cuda code of lightconv and dynamicconv

### DIFF
--- a/fairseq/modules/dynamicconv_layer/dynamicconv_cuda_kernel.cu
+++ b/fairseq/modules/dynamicconv_layer/dynamicconv_cuda_kernel.cu
@@ -6,8 +6,6 @@
  */
 
 #include "dynamicconv_cuda.cuh"
-#include "dynamicconv_cuda_forward.cu"
-#include "dynamicconv_cuda_backward.cu"
 #include "../cuda_utils.cu"
 
 // FS is filter size and kernels are specialized for filter sizes

--- a/fairseq/modules/lightconv_layer/lightconv_cuda_kernel.cu
+++ b/fairseq/modules/lightconv_layer/lightconv_cuda_kernel.cu
@@ -6,8 +6,6 @@
  */
 
 #include "lightconv_cuda.cuh"
-#include "lightconv_cuda_forward.cu"
-#include "lightconv_cuda_backward.cu"
 #include "../cuda_utils.cu"
 
 template<int FS, int SB, int padding_l, typename scalar_t>


### PR DESCRIPTION
The cuda code for `lightconv` and dynamicconv` include some files that do not exist.