### PR TITLE
Add 'ppl'  to tensorboard

### DIFF
--- a/fairseq/utils.py
+++ b/fairseq/utils.py
@@ -306,7 +306,7 @@ def log_softmax(x, dim, onnx_trace=False):
 
 def get_perplexity(loss):
     try:
-        return '{:.2f}'.format(math.pow(2, loss))
+        return float('{:.2f}'.format(math.pow(2, loss)))
     except OverflowError:
         return float('inf')
 


### PR DESCRIPTION
Originally, the 'ppl' is calculated but returned as a string, which will not be printed to the tensorboard.