### PR TITLE
fixed a bug in preprocess glue dataset dev filename

### DIFF
--- a/examples/roberta/preprocess_GLUE_tasks.sh
+++ b/examples/roberta/preprocess_GLUE_tasks.sh
@@ -173,7 +173,7 @@ do
     fairseq-preprocess \
       --only-source \
       --trainpref "$TASK_DATA_FOLDER/processed/train.label" \
-      --validpref "${DEVPREF//LANG/'label'}" \
+      --validpref "${DEVPREF//LANG/label}" \
       --destdir "$TASK-bin/label" \
       --workers 60;
   else


### PR DESCRIPTION
removed redundant quotes in the filename assigned for dev dataset for GLUE tasks