### PR TITLE
Quick fix for Structured Dropout checkpointing

### DIFF
--- a/fairseq/checkpoint_utils.py
+++ b/fairseq/checkpoint_utils.py
@@ -395,6 +395,13 @@ def prune_state_dict(state_dict, args):
                 new_state_key = layer_name[:substitution_match.start(1)] + new_layer_number + layer_name[substitution_match.end(1):]
                 new_state_dict[new_state_key] = state_dict[layer_name]
 
+    # Since layers are now pruned, *_layers_to_keep are no longer needed.
+    # This is more of "It would make it work fix" rather than a proper fix.
+    if "encoder_layers_to_keep" in vars(args):
+        args.encoder_layers_to_keep = None
+    if "decoder_layers_to_keep" in vars(args):
+        args.decoder_layers_to_keep = None
+
     return new_state_dict
 
 

--- a/fairseq/models/fairseq_model.py
+++ b/fairseq/models/fairseq_model.py
@@ -68,14 +68,6 @@ class BaseFairseqModel(nn.Module):
         """
         self.upgrade_state_dict(state_dict)
         new_state_dict = prune_state_dict(state_dict, args)
-
-        # Since layers are now pruned, *_layers_to_keep are no longer needed.
-        # This is more of "It would make it work fix" rather than a proper fix.
-        if "encoder_layers_to_keep" in vars(args):
-            args.encoder_layers_to_keep = None
-        if "decoder_layers_to_keep" in vars(args):
-            args.decoder_layers_to_keep = None
-
         return super().load_state_dict(new_state_dict, strict)
 
     def upgrade_state_dict(self, state_dict):

--- a/fairseq/models/fairseq_model.py
+++ b/fairseq/models/fairseq_model.py
@@ -68,6 +68,14 @@ class BaseFairseqModel(nn.Module):
         """
         self.upgrade_state_dict(state_dict)
         new_state_dict = prune_state_dict(state_dict, args)
+
+        # Since layers are now pruned, *_layers_to_keep are no longer needed.
+        # This is more of "It would make it work fix" rather than a proper fix.
+        if "encoder_layers_to_keep" in vars(args):
+            args.encoder_layers_to_keep = None
+        if "decoder_layers_to_keep" in vars(args):
+            args.decoder_layers_to_keep = None
+
         return super().load_state_dict(new_state_dict, strict)
 
     def upgrade_state_dict(self, state_dict):


### PR DESCRIPTION
Here's a quick fix for https://github.com/pytorch/fairseq/issues/1403.

To keep it short, this fix allows the user to checkpoint a translation model properly after applying layer pruning on a restored transformer file.