### PR TITLE
Fix shape issue of `return_all_hiddens` in roberta

### DIFF
--- a/fairseq/models/roberta/model.py
+++ b/fairseq/models/roberta/model.py
@@ -360,7 +360,7 @@ class RobertaEncoder(FairseqDecoder):
         )
         features = inner_states[-1]
         if return_all_hiddens:
-            features=features.transpose(0,1)
+            features = features.transpose(0,1)
         return features, {'inner_states': inner_states if return_all_hiddens else None}
 
     def output_layer(self, features, masked_tokens=None, **unused):

--- a/fairseq/models/roberta/model.py
+++ b/fairseq/models/roberta/model.py
@@ -359,6 +359,8 @@ class RobertaEncoder(FairseqDecoder):
             last_state_only=not return_all_hiddens,
         )
         features = inner_states[-1]
+        if return_all_hiddens:
+            features=features.transpose(0,1)
         return features, {'inner_states': inner_states if return_all_hiddens else None}
 
     def output_layer(self, features, masked_tokens=None, **unused):


### PR DESCRIPTION
By default `return_all_hiddens` is False, the shape of `features` will be BxTxC.
If use `return_all_hiddens`, the shape of `features` will be TxBxC.
See 
https://github.com/pytorch/fairseq/blob/9398a2829596393b73f5c5f1b99edf4c2d8f9316/fairseq/modules/transformer_sentence_encoder.py#L227