### PR TITLE
Use the HTTPS URL for cloning fastBPE

### DIFF
--- a/examples/joint_alignment_translation/prepare-wmt18en2de_no_norm_no_escape_no_agressive.sh
+++ b/examples/joint_alignment_translation/prepare-wmt18en2de_no_norm_no_escape_no_agressive.sh
@@ -110,7 +110,7 @@ mkdir output
 mv $tmp/{train,valid,test}.{$src,$tgt} output
 
 #BPE
-git clone git@github.com:glample/fastBPE.git
+git clone https://github.com/glample/fastBPE.git
 pushd fastBPE
 g++ -std=c++11 -pthread -O3 fastBPE/main.cc -IfastBPE -o fast
 popd


### PR DESCRIPTION
Cloning with SSH URL raises permission error.