### PR TITLE
[fix] ensure self.scale_window is an integer

### DIFF
--- a/fairseq/optim/fp16_optimizer.py
+++ b/fairseq/optim/fp16_optimizer.py
@@ -185,7 +185,7 @@ class FP16Optimizer(_FP16OptimizerMixin, optim.FairseqOptimizer):
                     '--fp16-scale-window must be given explicitly when using a '
                     'custom --update-freq schedule'
                 )
-            scale_window = 2**14 / args.distributed_world_size / args.update_freq[0]
+            scale_window = int(2**14 / args.distributed_world_size / args.update_freq[0])
         else:
             scale_window = args.fp16_scale_window
 


### PR DESCRIPTION
The scale window condition is `elif (self._iter - self._last_overflow_iter) % self.scale_window == 0`, which requires self.scale_window is an integer. If self.scale_window is float, the result of `(self._iter - self._last_overflow_iter) % self.scale_window` will never be 0.