### PR TITLE
Fairseq: Save predictions in logging output for evaluating MAP and MAUC

### DIFF
--- a/fairseq/criterions/binary_cross_entropy.py
+++ b/fairseq/criterions/binary_cross_entropy.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
+import numpy as np
 import torch
 import torch.nn.functional as F
 
@@ -18,7 +19,7 @@ class BinaryCrossEntropyCriterion(FairseqCriterion):
     def __init__(self, args, task):
         super().__init__(args, task)
 
-    def forward(self, model, sample, reduce=True):
+    def forward(self, model, sample, reduce=True, log_pred=False):
         """Compute the loss for the given sample.
 
         Returns a tuple with three elements:
@@ -51,6 +52,9 @@ class BinaryCrossEntropyCriterion(FairseqCriterion):
             'nsentences': logits.size(0),
             'sample_size': sample_size,
         }
+        if log_pred:
+            logging_output['logits'] = logits.cpu().numpy()
+            logging_output['target'] = target.cpu().numpy()
         return loss, sample_size, logging_output
 
     @staticmethod
@@ -68,4 +72,12 @@ class BinaryCrossEntropyCriterion(FairseqCriterion):
         }
         if sample_size != ntokens:
             agg_output['nll_loss'] = loss_sum / ntokens / math.log(2)
+        for key in ["logits", "target"]:
+            if key in logging_outputs[0]:
+                if len(logging_outputs) == 1:
+                    agg_output[key] = logging_outputs[0][key]  # avoid copying
+                else:
+                    agg_output[key] = np.concatenate(
+                        [log[key] for log in logging_outputs]
+                    )
         return agg_output


### PR DESCRIPTION
Summary:
In sound event detection, the evaluation metrics are mean average precision (MAP) and mean area under the curve (MAUC).
These metrics evaluate how well the system *sorts* instances.
They are not decomposable across instances, so one needs to collect the predictions and truths of all instances of a validation set.

This diff adds a switch `log_pred` to the `forward` function of the binary cross entropy.
When this switch is turned on, it saves the predictions and truths to the `logging_output` dictionary.

This dictionary needs to be synced across workers by the `all_gather_list` function in `distributed_utils.py`.
The existing implementation restricts the size of the dictionary to 64KB, because it only allocates 2 bytes for the size during serialization. The predictions and truths often exceed this limit.
This diff uses 4 bytes for the size during serialization, and increases the limit.

Reviewed By: myleott

Differential Revision: D18922980

