### PR TITLE
Script MultiheadAttention

### DIFF
--- a/fairseq/incremental_decoding_utils.py
+++ b/fairseq/incremental_decoding_utils.py
@@ -1,0 +1,24 @@
+from fairseq import utils
+
+
+class FairseqIncrementalState(object):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        init_incremental_state(self)
+
+
+def with_incremental_state(cls):
+    cls.__bases__ = (FairseqIncrementalState,) + tuple(b for b in cls.__bases__ if b != FairseqIncrementalState)
+    return cls
+
+
+# In most cases we should register incremental states using @with_incremental_state decorator
+# instead of calling into this explicitly in initializer.
+def init_incremental_state(obj):
+    obj.module_name = obj.__class__.__name__
+    utils.INCREMENTAL_STATE_INSTANCE_ID[obj.module_name] = (
+        utils.INCREMENTAL_STATE_INSTANCE_ID.get(obj.module_name, 0) + 1
+    )
+    obj._fairseq_instance_id = utils.INCREMENTAL_STATE_INSTANCE_ID[
+        obj.module_name
+    ]

--- a/fairseq/iterative_refinement_generator.py
+++ b/fairseq/iterative_refinement_generator.py
@@ -223,7 +223,7 @@ class IterativeRefinementGenerator(object):
             finalized_tokens = decoder_out.output_tokens[terminated]
             finalized_scores = decoder_out.output_scores[terminated]
             finalized_attn = (
-                None if decoder_out.attn is None else decoder_out.attn[terminated]
+                None if (decoder_out.attn is None or decoder_out.attn.size(0) == 0) else decoder_out.attn[terminated]
             )
 
             if self.retain_history:
@@ -259,8 +259,12 @@ class IterativeRefinementGenerator(object):
             prev_decoder_out = decoder_out._replace(
                 output_tokens=decoder_out.output_tokens[not_terminated],
                 output_scores=decoder_out.output_scores[not_terminated],
-                attn=decoder_out.attn[not_terminated] if decoder_out.attn is not None else None,
-                history=[h[not_terminated] for h in decoder_out.history] if decoder_out.history is not None else None
+                attn=decoder_out.attn[not_terminated]
+                if (decoder_out.attn is not None and decoder_out.attn.size(0) > 0)
+                else None,
+                history=[h[not_terminated] for h in decoder_out.history]
+                if decoder_out.history is not None
+                else None,
             )
             encoder_out = model.encoder.reorder_encoder_out(encoder_out, not_terminated.nonzero().squeeze())
             sent_idxs = sent_idxs[not_terminated]

--- a/fairseq/models/fairseq_decoder.py
+++ b/fairseq/models/fairseq_decoder.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch.nn as nn
-
 from fairseq import utils
 
 
@@ -29,7 +28,9 @@ class FairseqDecoder(nn.Module):
                 - the decoder's output of shape `(batch, tgt_len, vocab)`
                 - a dictionary with any model-specific outputs
         """
-        x, extra = self.extract_features(prev_output_tokens, encoder_out=encoder_out, **kwargs)
+        x, extra = self.extract_features(
+            prev_output_tokens, encoder_out=encoder_out, **kwargs
+        )
         x = self.output_layer(x)
         return x, extra
 
@@ -54,10 +55,10 @@ class FairseqDecoder(nn.Module):
     def get_normalized_probs(self, net_output, log_probs, sample):
         """Get normalized probabilities (or log probs) from a net's output."""
 
-        if hasattr(self, 'adaptive_softmax') and self.adaptive_softmax is not None:
+        if hasattr(self, "adaptive_softmax") and self.adaptive_softmax is not None:
             if sample is not None:
-                assert 'target' in sample
-                target = sample['target']
+                assert "target" in sample
+                target = sample["target"]
             else:
                 target = None
             out = self.adaptive_softmax.get_log_prob(net_output[0], target=target)

--- a/fairseq/models/fairseq_incremental_decoder.py
+++ b/fairseq/models/fairseq_incremental_decoder.py
@@ -4,8 +4,10 @@
 # LICENSE file in the root directory of this source tree.
 
 from fairseq.models import FairseqDecoder
+from fairseq.incremental_decoding_utils import with_incremental_state
 
 
+@with_incremental_state
 class FairseqIncrementalDecoder(FairseqDecoder):
     """Base class for incremental decoders.
 

--- a/fairseq/models/fconv_self_att.py
+++ b/fairseq/models/fconv_self_att.py
@@ -26,7 +26,7 @@ from fairseq.modules import (
     LearnedPositionalEmbedding,
     LinearizedConvolution,
 )
-
+from fairseq.incremental_decoding_utils import with_incremental_state
 
 @register_model('fconv_self_att')
 class FConvModelSelfAtt(FairseqEncoderDecoderModel):
@@ -287,6 +287,7 @@ class FConvEncoder(FairseqEncoder):
         return self.embed_positions.max_positions()
 
 
+@with_incremental_state
 class FConvDecoder(FairseqDecoder):
     """Convolutional decoder"""
     def __init__(

--- a/fairseq/modules/dynamic_convolution.py
+++ b/fairseq/modules/dynamic_convolution.py
@@ -9,6 +9,7 @@ import torch.nn.functional as F
 
 from fairseq import utils
 from .unfold import unfold1d
+from fairseq.incremental_decoding_utils import with_incremental_state
 
 
 def DynamicConv(input_size, kernel_size=1, padding_l=None, num_heads=1,
@@ -38,6 +39,7 @@ def Linear(in_features, out_features, bias=True):
     return m
 
 
+@with_incremental_state
 class DynamicConv1dTBC(nn.Module):
     '''Dynamic lightweight convolution taking T x B x C inputs
     Args:

--- a/fairseq/modules/lightweight_convolution.py
+++ b/fairseq/modules/lightweight_convolution.py
@@ -9,6 +9,7 @@ import torch.nn.functional as F
 
 from fairseq import utils
 from fairseq.modules.unfold import unfold1d
+from fairseq.incremental_decoding_utils import with_incremental_state
 
 
 def LightweightConv(input_size, kernel_size=1, padding_l=None, num_heads=1,
@@ -99,6 +100,7 @@ class LightweightConv1d(nn.Module):
         return output
 
 
+@with_incremental_state
 class LightweightConv1dTBC(nn.Module):
     '''Lightweight Convolution assuming the input is TxBxC
     Args:
@@ -136,7 +138,6 @@ class LightweightConv1dTBC(nn.Module):
             self.bias = None
 
         self.reset_parameters()
-
         self.onnx_trace = False
 
     def reset_parameters(self):

--- a/fairseq/modules/linearized_convolution.py
+++ b/fairseq/modules/linearized_convolution.py
@@ -7,10 +7,11 @@ import torch
 import torch.nn.functional as F
 
 from fairseq import utils
-
 from .conv_tbc import ConvTBC
+from fairseq.incremental_decoding_utils import with_incremental_state
 
 
+@with_incremental_state
 class LinearizedConvolution(ConvTBC):
     """An optimized version of nn.Conv1d.
 

--- a/fairseq/modules/multihead_attention.py
+++ b/fairseq/modules/multihead_attention.py
@@ -4,12 +4,12 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
+
 import torch
+import torch.nn.functional as F
+from fairseq import utils
 from torch import nn
 from torch.nn import Parameter
-import torch.nn.functional as F
-
-from fairseq import utils
 
 
 class MultiheadAttention(nn.Module):
@@ -18,9 +18,19 @@ class MultiheadAttention(nn.Module):
     See "Attention Is All You Need" for more details.
     """
 
-    def __init__(self, embed_dim, num_heads, kdim=None, vdim=None, dropout=0., bias=True,
-                 add_bias_kv=False, add_zero_attn=False, self_attention=False,
-                 encoder_decoder_attention=False):
+    def __init__(
+        self,
+        embed_dim,
+        num_heads,
+        kdim=None,
+        vdim=None,
+        dropout=0.0,
+        bias=True,
+        add_bias_kv=False,
+        add_zero_attn=False,
+        self_attention=False,
+        encoder_decoder_attention=False,
+    ):
         super().__init__()
         self.embed_dim = embed_dim
         self.kdim = kdim if kdim is not None else embed_dim
@@ -30,14 +40,17 @@ class MultiheadAttention(nn.Module):
         self.num_heads = num_heads
         self.dropout = dropout
         self.head_dim = embed_dim // num_heads
-        assert self.head_dim * num_heads == self.embed_dim, "embed_dim must be divisible by num_heads"
+        assert (
+            self.head_dim * num_heads == self.embed_dim
+        ), "embed_dim must be divisible by num_heads"
         self.scaling = self.head_dim ** -0.5
 
         self.self_attention = self_attention
         self.encoder_decoder_attention = encoder_decoder_attention
 
-        assert not self.self_attention or self.qkv_same_dim, 'Self-attention requires query, key and ' \
-                                                             'value to be of the same size'
+        assert not self.self_attention or self.qkv_same_dim, (
+            "Self-attention requires query, key and " "value to be of the same size"
+        )
 
         self.k_proj = nn.Linear(self.kdim, embed_dim, bias=bias)
         self.v_proj = nn.Linear(self.vdim, embed_dim, bias=bias)
@@ -70,9 +83,9 @@ class MultiheadAttention(nn.Module):
         if self.qkv_same_dim:
             # Empirically observed the convergence to be much better with
             # the scaled initialization
-            nn.init.xavier_uniform_(self.k_proj.weight, gain=1/math.sqrt(2))
-            nn.init.xavier_uniform_(self.v_proj.weight, gain=1/math.sqrt(2))
-            nn.init.xavier_uniform_(self.q_proj.weight, gain=1/math.sqrt(2))
+            nn.init.xavier_uniform_(self.k_proj.weight, gain=1 / math.sqrt(2))
+            nn.init.xavier_uniform_(self.v_proj.weight, gain=1 / math.sqrt(2))
+            nn.init.xavier_uniform_(self.q_proj.weight, gain=1 / math.sqrt(2))
         else:
             nn.init.xavier_uniform_(self.k_proj.weight)
             nn.init.xavier_uniform_(self.v_proj.weight)
@@ -88,7 +101,9 @@ class MultiheadAttention(nn.Module):
 
     def forward(
         self,
-        query, key, value,
+        query,
+        key,
+        value,
         key_padding_mask=None,
         incremental_state=None,
         need_weights=True,
@@ -121,23 +136,39 @@ class MultiheadAttention(nn.Module):
         assert embed_dim == self.embed_dim
         assert list(query.size()) == [tgt_len, bsz, embed_dim]
 
-        if self.enable_torch_version and not self.onnx_trace and incremental_state is None and not static_kv:
-            return F.multi_head_attention_forward(query, key, value,
-                                                  self.embed_dim, self.num_heads,
-                                                  torch.empty([0]),
-                                                  torch.cat((self.q_proj.bias, self.k_proj.bias, self.v_proj.bias)),
-                                                  self.bias_k, self.bias_v,
-                                                  self.add_zero_attn, self.dropout,
-                                                  self.out_proj.weight, self.out_proj.bias,
-                                                  self.training, key_padding_mask, need_weights,
-                                                  attn_mask, use_separate_proj_weight=True,
-                                                  q_proj_weight=self.q_proj.weight,
-                                                  k_proj_weight=self.k_proj.weight,
-                                                  v_proj_weight=self.v_proj.weight)
+        if (
+            self.enable_torch_version
+            and not self.onnx_trace
+            and incremental_state is None
+            and not static_kv
+        ):
+            return F.multi_head_attention_forward(
+                query,
+                key,
+                value,
+                self.embed_dim,
+                self.num_heads,
+                torch.empty([0]),
+                torch.cat((self.q_proj.bias, self.k_proj.bias, self.v_proj.bias)),
+                self.bias_k,
+                self.bias_v,
+                self.add_zero_attn,
+                self.dropout,
+                self.out_proj.weight,
+                self.out_proj.bias,
+                self.training,
+                key_padding_mask,
+                need_weights,
+                attn_mask,
+                use_separate_proj_weight=True,
+                q_proj_weight=self.q_proj.weight,
+                k_proj_weight=self.k_proj.weight,
+                v_proj_weight=self.v_proj.weight,
+            )
 
         if incremental_state is not None:
             saved_state = self._get_input_buffer(incremental_state)
-            if 'prev_key' in saved_state:
+            if "prev_key" in saved_state:
                 # previous time steps are cached - no need to recompute
                 # key and value if they are static
                 if static_kv:
@@ -171,42 +202,65 @@ class MultiheadAttention(nn.Module):
             k = torch.cat([k, self.bias_k.repeat(1, bsz, 1)])
             v = torch.cat([v, self.bias_v.repeat(1, bsz, 1)])
             if attn_mask is not None:
-                attn_mask = torch.cat([attn_mask, attn_mask.new_zeros(attn_mask.size(0), 1)], dim=1)
+                attn_mask = torch.cat(
+                    [attn_mask, attn_mask.new_zeros(attn_mask.size(0), 1)], dim=1
+                )
             if key_padding_mask is not None:
                 key_padding_mask = torch.cat(
-                    [key_padding_mask, key_padding_mask.new_zeros(key_padding_mask.size(0), 1)], dim=1)
+                    [
+                        key_padding_mask,
+                        key_padding_mask.new_zeros(key_padding_mask.size(0), 1),
+                    ],
+                    dim=1,
+                )
 
-        q = q.contiguous().view(tgt_len, bsz * self.num_heads, self.head_dim).transpose(0, 1)
+        q = (
+            q.contiguous()
+            .view(tgt_len, bsz * self.num_heads, self.head_dim)
+            .transpose(0, 1)
+        )
         if k is not None:
-            k = k.contiguous().view(-1, bsz * self.num_heads, self.head_dim).transpose(0, 1)
+            k = (
+                k.contiguous()
+                .view(-1, bsz * self.num_heads, self.head_dim)
+                .transpose(0, 1)
+            )
         if v is not None:
-            v = v.contiguous().view(-1, bsz * self.num_heads, self.head_dim).transpose(0, 1)
+            v = (
+                v.contiguous()
+                .view(-1, bsz * self.num_heads, self.head_dim)
+                .transpose(0, 1)
+            )
 
         if saved_state is not None:
             # saved states are stored with shape (bsz, num_heads, seq_len, head_dim)
-            if 'prev_key' in saved_state:
-                prev_key = saved_state['prev_key'].view(bsz * self.num_heads, -1, self.head_dim)
+            if "prev_key" in saved_state:
+                prev_key = saved_state["prev_key"].view(
+                    bsz * self.num_heads, -1, self.head_dim
+                )
                 if static_kv:
                     k = prev_key
                 else:
                     k = torch.cat((prev_key, k), dim=1)
-            if 'prev_value' in saved_state:
-                prev_value = saved_state['prev_value'].view(bsz * self.num_heads, -1, self.head_dim)
+            if "prev_value" in saved_state:
+                prev_value = saved_state["prev_value"].view(
+                    bsz * self.num_heads, -1, self.head_dim
+                )
                 if static_kv:
                     v = prev_value
                 else:
                     v = torch.cat((prev_value, v), dim=1)
             key_padding_mask = self._append_prev_key_padding_mask(
                 key_padding_mask=key_padding_mask,
-                prev_key_padding_mask=saved_state.get('prev_key_padding_mask', None),
+                prev_key_padding_mask=saved_state.get("prev_key_padding_mask", None),
                 batch_size=bsz,
                 src_len=k.size(1),
                 static_kv=static_kv,
             )
 
-            saved_state['prev_key'] = k.view(bsz, self.num_heads, -1, self.head_dim)
-            saved_state['prev_value'] = v.view(bsz, self.num_heads, -1, self.head_dim)
-            saved_state['prev_key_padding_mask'] = key_padding_mask
+            saved_state["prev_key"] = k.view(bsz, self.num_heads, -1, self.head_dim)
+            saved_state["prev_value"] = v.view(bsz, self.num_heads, -1, self.head_dim)
+            saved_state["prev_key_padding_mask"] = key_padding_mask
 
             self._set_input_buffer(incremental_state, saved_state)
 
@@ -226,10 +280,19 @@ class MultiheadAttention(nn.Module):
             k = torch.cat([k, k.new_zeros((k.size(0), 1) + k.size()[2:])], dim=1)
             v = torch.cat([v, v.new_zeros((v.size(0), 1) + v.size()[2:])], dim=1)
             if attn_mask is not None:
-                attn_mask = torch.cat([attn_mask, attn_mask.new_zeros(attn_mask.size(0), 1)], dim=1)
+                attn_mask = torch.cat(
+                    [attn_mask, attn_mask.new_zeros(attn_mask.size(0), 1)], dim=1
+                )
             if key_padding_mask is not None:
                 key_padding_mask = torch.cat(
-                    [key_padding_mask, torch.zeros(key_padding_mask.size(0), 1).type_as(key_padding_mask)], dim=1)
+                    [
+                        key_padding_mask,
+                        torch.zeros(key_padding_mask.size(0), 1).type_as(
+                            key_padding_mask
+                        ),
+                    ],
+                    dim=1,
+                )
 
         attn_weights = torch.bmm(q, k.transpose(1, 2))
         attn_weights = self.apply_sparse_mask(attn_weights, tgt_len, src_len, bsz)
@@ -246,21 +309,26 @@ class MultiheadAttention(nn.Module):
             # don't attend to padding symbols
             attn_weights = attn_weights.view(bsz, self.num_heads, tgt_len, src_len)
             attn_weights = attn_weights.masked_fill(
-                key_padding_mask.unsqueeze(1).unsqueeze(2),
-                float('-inf'),
+                key_padding_mask.unsqueeze(1).unsqueeze(2), float("-inf")
             )
             attn_weights = attn_weights.view(bsz * self.num_heads, tgt_len, src_len)
 
         if before_softmax:
             return attn_weights, v
 
-        attn_weights_float = utils.softmax(attn_weights, dim=-1, onnx_trace=self.onnx_trace)
+        attn_weights_float = utils.softmax(
+            attn_weights, dim=-1, onnx_trace=self.onnx_trace
+        )
         attn_weights = attn_weights_float.type_as(attn_weights)
-        attn_probs = F.dropout(attn_weights_float.type_as(attn_weights), p=self.dropout, training=self.training)
+        attn_probs = F.dropout(
+            attn_weights_float.type_as(attn_weights),
+            p=self.dropout,
+            training=self.training,
+        )
 
         attn = torch.bmm(attn_probs, v)
         assert list(attn.size()) == [bsz * self.num_heads, tgt_len, self.head_dim]
-        if (self.onnx_trace and attn.size(1) == 1):
+        if self.onnx_trace and attn.size(1) == 1:
             # when ONNX tracing a single decoder step (sequence length == 1)
             # the transpose is a no-op copy before view, thus unnecessary
             attn = attn.contiguous().view(tgt_len, bsz, embed_dim)
@@ -269,7 +337,9 @@ class MultiheadAttention(nn.Module):
         attn = self.out_proj(attn)
 
         if need_weights:
-            attn_weights = attn_weights_float.view(bsz, self.num_heads, tgt_len, src_len).transpose(1, 0)
+            attn_weights = attn_weights_float.view(
+                bsz, self.num_heads, tgt_len, src_len
+            ).transpose(1, 0)
             if not need_head_weights:
                 # average attention weights over heads
                 attn_weights = attn_weights.mean(dim=0)
@@ -280,22 +350,22 @@ class MultiheadAttention(nn.Module):
 
     @staticmethod
     def _append_prev_key_padding_mask(
-        key_padding_mask,
-        prev_key_padding_mask,
-        batch_size,
-        src_len,
-        static_kv,
+        key_padding_mask, prev_key_padding_mask, batch_size, src_len, static_kv
     ):
         # saved key padding masks have shape (bsz, seq_len)
         if prev_key_padding_mask is not None and static_kv:
             key_padding_mask = prev_key_padding_mask
         elif prev_key_padding_mask is not None and key_padding_mask is not None:
-            key_padding_mask = torch.cat((prev_key_padding_mask, key_padding_mask), dim=1)
+            key_padding_mask = torch.cat(
+                (prev_key_padding_mask, key_padding_mask), dim=1
+            )
         # During incremental decoding, as the padding token enters and
         # leaves the frame, there will be a time when prev or current
         # is None
         elif prev_key_padding_mask is not None:
-            filler = torch.zeros(batch_size, src_len - prev_key_padding_mask.size(1)).bool()
+            filler = torch.zeros(
+                batch_size, src_len - prev_key_padding_mask.size(1)
+            ).bool()
             if prev_key_padding_mask.is_cuda:
                 filler = filler.cuda()
             key_padding_mask = torch.cat((prev_key_padding_mask, filler), dim=1)
@@ -316,45 +386,38 @@ class MultiheadAttention(nn.Module):
             self._set_input_buffer(incremental_state, input_buffer)
 
     def _get_input_buffer(self, incremental_state):
-        return utils.get_incremental_state(
-            self,
-            incremental_state,
-            'attn_state',
-        ) or {}
+        return utils.get_incremental_state(self, incremental_state, "attn_state") or {}
 
     def _set_input_buffer(self, incremental_state, buffer):
-        utils.set_incremental_state(
-            self,
-            incremental_state,
-            'attn_state',
-            buffer,
-        )
+        utils.set_incremental_state(self, incremental_state, "attn_state", buffer)
 
     def apply_sparse_mask(self, attn_weights, tgt_len, src_len, bsz):
         return attn_weights
 
     def upgrade_state_dict_named(self, state_dict, name):
-        prefix = name + '.' if name != '' else ''
+        prefix = name + "." if name != "" else ""
         items_to_add = {}
         keys_to_remove = []
         for k in state_dict.keys():
-            if k.endswith(prefix + 'in_proj_weight'):
+            if k.endswith(prefix + "in_proj_weight"):
                 # in_proj_weight used to be q + k + v with same dimensions
                 dim = int(state_dict[k].shape[0] / 3)
-                items_to_add[prefix + 'q_proj.weight'] = state_dict[k][:dim]
-                items_to_add[prefix + 'k_proj.weight'] = state_dict[k][dim:2*dim]
-                items_to_add[prefix + 'v_proj.weight'] = state_dict[k][2*dim:]
+                items_to_add[prefix + "q_proj.weight"] = state_dict[k][:dim]
+                items_to_add[prefix + "k_proj.weight"] = state_dict[k][dim : 2 * dim]
+                items_to_add[prefix + "v_proj.weight"] = state_dict[k][2 * dim :]
 
                 keys_to_remove.append(k)
 
-                k_bias = prefix + 'in_proj_bias'
+                k_bias = prefix + "in_proj_bias"
                 if k_bias in state_dict.keys():
                     dim = int(state_dict[k].shape[0] / 3)
-                    items_to_add[prefix + 'q_proj.bias'] = state_dict[k_bias][:dim]
-                    items_to_add[prefix + 'k_proj.bias'] = state_dict[k_bias][dim:2*dim]
-                    items_to_add[prefix + 'v_proj.bias'] = state_dict[k_bias][2*dim:]
+                    items_to_add[prefix + "q_proj.bias"] = state_dict[k_bias][:dim]
+                    items_to_add[prefix + "k_proj.bias"] = state_dict[k_bias][
+                        dim : 2 * dim
+                    ]
+                    items_to_add[prefix + "v_proj.bias"] = state_dict[k_bias][2 * dim :]
 
-                    keys_to_remove.append(prefix + 'in_proj_bias')
+                    keys_to_remove.append(prefix + "in_proj_bias")
 
         for k in keys_to_remove:
             del state_dict[k]

--- a/fairseq/modules/multihead_attention.py
+++ b/fairseq/modules/multihead_attention.py
@@ -4,14 +4,17 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
+from typing import Dict, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
 from fairseq import utils
-from torch import nn
+from torch import Tensor, nn
 from torch.nn import Parameter
+from fairseq.incremental_decoding_utils import with_incremental_state
 
 
+@with_incremental_state
 class MultiheadAttention(nn.Module):
     """Multi-headed attention.
 
@@ -102,16 +105,16 @@ class MultiheadAttention(nn.Module):
     def forward(
         self,
         query,
-        key,
-        value,
-        key_padding_mask=None,
-        incremental_state=None,
-        need_weights=True,
-        static_kv=False,
-        attn_mask=None,
-        before_softmax=False,
-        need_head_weights=False,
-    ):
+        key: Optional[Tensor],
+        value: Optional[Tensor],
+        key_padding_mask: Optional[Tensor] = None,
+        incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]] = None,
+        need_weights: bool = True,
+        static_kv: bool = False,
+        attn_mask: Optional[Tensor] = None,
+        before_softmax: bool = False,
+        need_head_weights: bool = False,
+    ) -> Tuple[Tensor, Optional[Tensor]]:
         """Input shape: Time x Batch x Channel
 
         Args:
@@ -142,6 +145,7 @@ class MultiheadAttention(nn.Module):
             and incremental_state is None
             and not static_kv
         ):
+            assert key is not None and value is not None
             return F.multi_head_attention_forward(
                 query,
                 key,
@@ -168,7 +172,7 @@ class MultiheadAttention(nn.Module):
 
         if incremental_state is not None:
             saved_state = self._get_input_buffer(incremental_state)
-            if "prev_key" in saved_state:
+            if saved_state is not None and "prev_key" in saved_state:
                 # previous time steps are cached - no need to recompute
                 # key and value if they are static
                 if static_kv:
@@ -192,6 +196,7 @@ class MultiheadAttention(nn.Module):
                 v = self.v_proj(key)
 
         else:
+            assert key is not None and value is not None
             q = self.q_proj(query)
             k = self.k_proj(key)
             v = self.v_proj(value)
@@ -235,24 +240,30 @@ class MultiheadAttention(nn.Module):
         if saved_state is not None:
             # saved states are stored with shape (bsz, num_heads, seq_len, head_dim)
             if "prev_key" in saved_state:
-                prev_key = saved_state["prev_key"].view(
-                    bsz * self.num_heads, -1, self.head_dim
-                )
+                _prev_key = saved_state["prev_key"]
+                assert _prev_key is not None
+                prev_key = _prev_key.view(bsz * self.num_heads, -1, self.head_dim)
                 if static_kv:
                     k = prev_key
                 else:
-                    k = torch.cat((prev_key, k), dim=1)
+                    assert k is not None
+                    k = torch.cat([prev_key, k], dim=1)
             if "prev_value" in saved_state:
-                prev_value = saved_state["prev_value"].view(
-                    bsz * self.num_heads, -1, self.head_dim
-                )
+                _prev_value = saved_state["prev_value"]
+                assert _prev_value is not None
+                prev_value = _prev_value.view(bsz * self.num_heads, -1, self.head_dim)
                 if static_kv:
                     v = prev_value
                 else:
-                    v = torch.cat((prev_value, v), dim=1)
-            key_padding_mask = self._append_prev_key_padding_mask(
+                    assert v is not None
+                    v = torch.cat([prev_value, v], dim=1)
+            prev_key_padding_mask: Optional[Tensor] = None
+            if "prev_key_padding_mask" in saved_state:
+                prev_key_padding_mask = saved_state["prev_key_padding_mask"]
+            assert k is not None and v is not None
+            key_padding_mask = MultiheadAttention._append_prev_key_padding_mask(
                 key_padding_mask=key_padding_mask,
-                prev_key_padding_mask=saved_state.get("prev_key_padding_mask", None),
+                prev_key_padding_mask=prev_key_padding_mask,
                 batch_size=bsz,
                 src_len=k.size(1),
                 static_kv=static_kv,
@@ -261,14 +272,15 @@ class MultiheadAttention(nn.Module):
             saved_state["prev_key"] = k.view(bsz, self.num_heads, -1, self.head_dim)
             saved_state["prev_value"] = v.view(bsz, self.num_heads, -1, self.head_dim)
             saved_state["prev_key_padding_mask"] = key_padding_mask
-
+            # In this branch incremental_state is never None
+            assert incremental_state is not None
             self._set_input_buffer(incremental_state, saved_state)
-
+        assert k is not None
         src_len = k.size(1)
 
         # This is part of a workaround to get around fork/join parallelism
         # not supporting Optional types.
-        if key_padding_mask is not None and key_padding_mask.shape == torch.Size([]):
+        if key_padding_mask is not None and key_padding_mask.dim() == 0:
             key_padding_mask = None
 
         if key_padding_mask is not None:
@@ -276,6 +288,7 @@ class MultiheadAttention(nn.Module):
             assert key_padding_mask.size(1) == src_len
 
         if self.add_zero_attn:
+            assert v is not None
             src_len += 1
             k = torch.cat([k, k.new_zeros((k.size(0), 1) + k.size()[2:])], dim=1)
             v = torch.cat([v, v.new_zeros((v.size(0), 1) + v.size()[2:])], dim=1)
@@ -295,7 +308,7 @@ class MultiheadAttention(nn.Module):
                 )
 
         attn_weights = torch.bmm(q, k.transpose(1, 2))
-        attn_weights = self.apply_sparse_mask(attn_weights, tgt_len, src_len, bsz)
+        attn_weights = MultiheadAttention.apply_sparse_mask(attn_weights, tgt_len, src_len, bsz)
 
         assert list(attn_weights.size()) == [bsz * self.num_heads, tgt_len, src_len]
 
@@ -309,7 +322,7 @@ class MultiheadAttention(nn.Module):
             # don't attend to padding symbols
             attn_weights = attn_weights.view(bsz, self.num_heads, tgt_len, src_len)
             attn_weights = attn_weights.masked_fill(
-                key_padding_mask.unsqueeze(1).unsqueeze(2), float("-inf")
+                key_padding_mask.unsqueeze(1).unsqueeze(2).to(torch.bool), float("-inf")
             )
             attn_weights = attn_weights.view(bsz * self.num_heads, tgt_len, src_len)
 
@@ -325,7 +338,7 @@ class MultiheadAttention(nn.Module):
             p=self.dropout,
             training=self.training,
         )
-
+        assert v is not None
         attn = torch.bmm(attn_probs, v)
         assert list(attn.size()) == [bsz * self.num_heads, tgt_len, self.head_dim]
         if self.onnx_trace and attn.size(1) == 1:
@@ -335,7 +348,7 @@ class MultiheadAttention(nn.Module):
         else:
             attn = attn.transpose(0, 1).contiguous().view(tgt_len, bsz, embed_dim)
         attn = self.out_proj(attn)
-
+        attn_weights: Optional[Tensor] = None
         if need_weights:
             attn_weights = attn_weights_float.view(
                 bsz, self.num_heads, tgt_len, src_len
@@ -343,40 +356,49 @@ class MultiheadAttention(nn.Module):
             if not need_head_weights:
                 # average attention weights over heads
                 attn_weights = attn_weights.mean(dim=0)
-        else:
-            attn_weights = None
 
         return attn, attn_weights
 
     @staticmethod
     def _append_prev_key_padding_mask(
-        key_padding_mask, prev_key_padding_mask, batch_size, src_len, static_kv
-    ):
+        key_padding_mask: Optional[Tensor],
+        prev_key_padding_mask: Optional[Tensor],
+        batch_size: int,
+        src_len: int,
+        static_kv: bool,
+    ) -> Optional[Tensor]:
         # saved key padding masks have shape (bsz, seq_len)
         if prev_key_padding_mask is not None and static_kv:
-            key_padding_mask = prev_key_padding_mask
+            new_key_padding_mask = prev_key_padding_mask
         elif prev_key_padding_mask is not None and key_padding_mask is not None:
-            key_padding_mask = torch.cat(
-                (prev_key_padding_mask, key_padding_mask), dim=1
+            new_key_padding_mask = torch.cat(
+                [prev_key_padding_mask.float(), key_padding_mask.float()], dim=1
             )
         # During incremental decoding, as the padding token enters and
         # leaves the frame, there will be a time when prev or current
         # is None
         elif prev_key_padding_mask is not None:
-            filler = torch.zeros(
-                batch_size, src_len - prev_key_padding_mask.size(1)
-            ).bool()
+
+            filler = torch.zeros(batch_size, src_len - prev_key_padding_mask.size(1))
             if prev_key_padding_mask.is_cuda:
                 filler = filler.cuda()
-            key_padding_mask = torch.cat((prev_key_padding_mask, filler), dim=1)
+            new_key_padding_mask = torch.cat(
+                [prev_key_padding_mask.float(), filler.float()], dim=1
+            )
         elif key_padding_mask is not None:
-            filler = torch.zeros(batch_size, src_len - key_padding_mask.size(1)).bool()
+            filler = torch.zeros(batch_size, src_len - key_padding_mask.size(1))
             if key_padding_mask.is_cuda:
                 filler = filler.cuda()
-            key_padding_mask = torch.cat((filler, key_padding_mask), dim=1)
-        return key_padding_mask
+            new_key_padding_mask = torch.cat(
+                [filler.float(), key_padding_mask.float()], dim=1
+            )
+        else:
+            new_key_padding_mask = prev_key_padding_mask
+        return new_key_padding_mask
 
-    def reorder_incremental_state(self, incremental_state, new_order):
+    def reorder_incremental_state(
+        self, incremental_state: Dict[str, Dict[str, Optional[Tensor]]], new_order
+    ):
         """Reorder buffered internal state (for incremental generation)."""
         input_buffer = self._get_input_buffer(incremental_state)
         if input_buffer is not None:
@@ -385,13 +407,28 @@ class MultiheadAttention(nn.Module):
                     input_buffer[k] = input_buffer[k].index_select(0, new_order)
             self._set_input_buffer(incremental_state, input_buffer)
 
-    def _get_input_buffer(self, incremental_state):
-        return utils.get_incremental_state(self, incremental_state, "attn_state") or {}
+    def _get_input_buffer(
+        self, incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]]
+    ) -> Dict[str, Optional[Tensor]]:
+        empty_dict_annotated: Dict[str, Optional[Tensor]] = {}
+        if incremental_state is None:
+            return empty_dict_annotated
+        full_key = utils._get_full_incremental_state_key(self, "attn_state")
+        if full_key not in incremental_state:
+            return empty_dict_annotated
+        return incremental_state[full_key]
 
-    def _set_input_buffer(self, incremental_state, buffer):
-        utils.set_incremental_state(self, incremental_state, "attn_state", buffer)
+    def _set_input_buffer(
+        self,
+        incremental_state: Dict[str, Dict[str, Optional[Tensor]]],
+        buffer: Dict[str, Optional[Tensor]],
+    ):
+        full_key = utils._get_full_incremental_state_key(
+            self, "attn_state"
+        )
+        incremental_state[full_key] = buffer
 
-    def apply_sparse_mask(self, attn_weights, tgt_len, src_len, bsz):
+    def apply_sparse_mask(attn_weights, tgt_len: int, src_len: int, bsz: int):
         return attn_weights
 
     def upgrade_state_dict_named(self, state_dict, name):

--- a/fairseq/modules/transformer_layer.py
+++ b/fairseq/modules/transformer_layer.py
@@ -225,10 +225,11 @@ class TransformerDecoderLayer(nn.Module):
             if len(prev_self_attn_state) >= 3:
                 saved_state["prev_key_padding_mask"] = prev_self_attn_state[2]
             self.self_attn._set_input_buffer(incremental_state, saved_state)
-
+        input_buffer = self.self_attn._get_input_buffer(incremental_state)
         if self.cross_self_attention and not (
             incremental_state is not None
-            and "prev_key" in self.self_attn._get_input_buffer(incremental_state)
+            and input_buffer is not None
+            and "prev_key" in input_buffer
         ):
             if self_attn_mask is not None:
                 self_attn_mask = torch.cat(

--- a/fairseq/sequence_generator.py
+++ b/fairseq/sequence_generator.py
@@ -274,6 +274,7 @@ class SequenceGenerator(object):
             lprobs, avg_attn_scores = model.forward_decoder(
                 tokens[:, :step + 1], encoder_outs, temperature=self.temperature,
             )
+            lprobs[lprobs != lprobs] = -math.inf
 
             lprobs[:, self.pad] = -math.inf  # never select pad
             lprobs[:, self.unk] -= self.unk_penalty  # apply unk penalty

--- a/fairseq/utils.py
+++ b/fairseq/utils.py
@@ -3,31 +3,31 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from collections import defaultdict
 import contextlib
 import copy
 import importlib.util
 import math
 import os
 import sys
-from typing import Callable, List
 import warnings
+from collections import defaultdict
+from itertools import accumulate
+from typing import Callable, List
 
 import torch
 import torch.nn.functional as F
-
-from itertools import accumulate
 from fairseq.modules import gelu, gelu_accurate
 
 
 def load_ensemble_for_inference(filenames, task, model_arg_overrides=None):
     from fairseq import checkpoint_utils
+
     deprecation_warning(
-        'utils.load_ensemble_for_inference is deprecated. '
-        'Please use checkpoint_utils.load_model_ensemble instead.'
+        "utils.load_ensemble_for_inference is deprecated. "
+        "Please use checkpoint_utils.load_model_ensemble instead."
     )
     return checkpoint_utils.load_model_ensemble(
-        filenames, arg_overrides=model_arg_overrides, task=task,
+        filenames, arg_overrides=model_arg_overrides, task=task
     )
 
 
@@ -39,10 +39,7 @@ def apply_to_sample(f, sample):
         if torch.is_tensor(x):
             return f(x)
         elif isinstance(x, dict):
-            return {
-                key: _apply(value)
-                for key, value in x.items()
-            }
+            return {key: _apply(value) for key, value in x.items()}
         elif isinstance(x, list):
             return [_apply(x) for x in x]
         else:
@@ -52,7 +49,6 @@ def apply_to_sample(f, sample):
 
 
 def move_to_cuda(sample):
-
     def _move_to_cuda(tensor):
         return tensor.cuda()
 
@@ -67,11 +63,13 @@ def _get_full_incremental_state_key(module_instance, key):
 
     # assign a unique ID to each module instance, so that incremental state is
     # not shared across module instances
-    if not hasattr(module_instance, '_fairseq_instance_id'):
+    if not hasattr(module_instance, "_fairseq_instance_id"):
         INCREMENTAL_STATE_INSTANCE_ID[module_name] += 1
-        module_instance._fairseq_instance_id = INCREMENTAL_STATE_INSTANCE_ID[module_name]
+        module_instance._fairseq_instance_id = INCREMENTAL_STATE_INSTANCE_ID[
+            module_name
+        ]
 
-    return '{}.{}.{}'.format(module_name, module_instance._fairseq_instance_id, key)
+    return "{}.{}.{}".format(module_name, module_instance._fairseq_instance_id, key)
 
 
 def get_incremental_state(module, incremental_state, key):
@@ -95,7 +93,7 @@ def load_align_dict(replace_unk):
     elif isinstance(replace_unk, str) and len(replace_unk) > 0:
         # Load alignment dictionary for unknown word replacement if it was passed as an argument.
         align_dict = {}
-        with open(replace_unk, 'r') as f:
+        with open(replace_unk, "r") as f:
             for line in f:
                 cols = line.split()
                 align_dict[cols[0]] = cols[1]
@@ -129,7 +127,9 @@ def parse_embedding(embed_path):
         next(f_embed)  # skip header
         for line in f_embed:
             pieces = line.rstrip().split(" ")
-            embed_dict[pieces[0]] = torch.Tensor([float(weight) for weight in pieces[1:]])
+            embed_dict[pieces[0]] = torch.Tensor(
+                [float(weight) for weight in pieces[1:]]
+            )
     return embed_dict
 
 
@@ -143,22 +143,27 @@ def load_embedding(embed_dict, vocab, embedding):
 
 def replace_unk(hypo_str, src_str, alignment, align_dict, unk):
     from fairseq import tokenizer
+
     # Tokens are strings here
     hypo_tokens = tokenizer.tokenize_line(hypo_str)
     # TODO: Very rare cases where the replacement is '<eos>' should be handled gracefully
-    src_tokens = tokenizer.tokenize_line(src_str) + ['<eos>']
+    src_tokens = tokenizer.tokenize_line(src_str) + ["<eos>"]
     for i, ht in enumerate(hypo_tokens):
         if ht == unk:
             src_token = src_tokens[alignment[i]]
             # Either take the corresponding value in the aligned dictionary or just copy the original value.
             hypo_tokens[i] = align_dict.get(src_token, src_token)
-    return ' '.join(hypo_tokens)
+    return " ".join(hypo_tokens)
 
 
-def post_process_prediction(hypo_tokens, src_str, alignment, align_dict, tgt_dict, remove_bpe=None):
+def post_process_prediction(
+    hypo_tokens, src_str, alignment, align_dict, tgt_dict, remove_bpe=None
+):
     hypo_str = tgt_dict.string(hypo_tokens, remove_bpe)
     if align_dict is not None:
-        hypo_str = replace_unk(hypo_str, src_str, alignment, align_dict, tgt_dict.unk_string())
+        hypo_str = replace_unk(
+            hypo_str, src_str, alignment, align_dict, tgt_dict.unk_string()
+        )
     if align_dict is not None or remove_bpe is not None:
         # Convert back to tokens for evaluating with unk replacement or without BPE
         # Note that the dictionary can be modified inside the method.
@@ -176,9 +181,7 @@ def make_positions(tensor, padding_idx, onnx_trace=False):
     # prefers ints, cumsum defaults to output longs, and ONNX doesn't know
     # how to handle the dtype kwarg in cumsum.
     mask = tensor.ne(padding_idx).int()
-    return (
-        torch.cumsum(mask, dim=1).type_as(mask) * mask
-    ).long() + padding_idx
+    return (torch.cumsum(mask, dim=1).type_as(mask) * mask).long() + padding_idx
 
 
 def strip_pad(tensor, pad):
@@ -186,14 +189,16 @@ def strip_pad(tensor, pad):
 
 
 def buffered_arange(max):
-    if not hasattr(buffered_arange, 'buf'):
+    if not hasattr(buffered_arange, "buf"):
         buffered_arange.buf = torch.LongTensor()
     if max > buffered_arange.buf.numel():
         torch.arange(max, out=buffered_arange.buf)
     return buffered_arange.buf[:max]
 
 
-def convert_padding_direction(src_tokens, padding_idx, right_to_left=False, left_to_right=False):
+def convert_padding_direction(
+    src_tokens, padding_idx, right_to_left=False, left_to_right=False
+):
     assert right_to_left ^ left_to_right
     pad_mask = src_tokens.eq(padding_idx)
     if not pad_mask.any():
@@ -216,9 +221,9 @@ def convert_padding_direction(src_tokens, padding_idx, right_to_left=False, left
 
 
 def item(tensor):
-    if hasattr(tensor, 'item'):
+    if hasattr(tensor, "item"):
         return tensor.item()
-    if hasattr(tensor, '__getitem__'):
+    if hasattr(tensor, "__getitem__"):
         return tensor[0]
     return tensor
 
@@ -233,7 +238,7 @@ def clip_grad_norm_(tensor, max_norm):
 
 def fill_with_neg_inf(t):
     """FP16-compatible function that fills a tensor with -inf."""
-    return t.float().fill_(float('-inf')).type_as(t)
+    return t.float().fill_(float("-inf")).type_as(t)
 
 
 def _match_types(arg1, arg2):
@@ -289,19 +294,19 @@ def resolve_max_positions(*args):
             elif isinstance(arg, dict):
                 max_positions = map_value_update(max_positions, arg)
             else:
-                max_positions = tuple(
-                    map(nullsafe_min, zip(max_positions, arg))
-                )
+                max_positions = tuple(map(nullsafe_min, zip(max_positions, arg)))
 
     return max_positions
 
 
 def import_user_module(args):
-    module_path = getattr(args, 'user_dir', None)
+    module_path = getattr(args, "user_dir", None)
     if module_path is not None:
         module_path = os.path.abspath(args.user_dir)
         if not os.path.exists(module_path):
-            fairseq_rel_path = os.path.join(os.path.dirname(__file__), '..', args.user_dir)
+            fairseq_rel_path = os.path.join(
+                os.path.dirname(__file__), "..", args.user_dir
+            )
             if os.path.exists(fairseq_rel_path):
                 module_path = fairseq_rel_path
         module_parent, module_name = os.path.split(module_path)
@@ -328,9 +333,9 @@ def log_softmax(x, dim, onnx_trace=False):
 
 def get_perplexity(loss):
     try:
-        return float('{:.2f}'.format(math.pow(2, loss)))
+        return float("{:.2f}".format(math.pow(2, loss)))
     except OverflowError:
-        return float('inf')
+        return float("inf")
 
 
 def deprecation_warning(message, stacklevel=3):
@@ -340,18 +345,20 @@ def deprecation_warning(message, stacklevel=3):
 
 def get_activation_fn(activation: str) -> Callable:
     """ Returns the activation function corresponding to `activation` """
-    if activation == 'relu':
+    if activation == "relu":
         return F.relu
-    elif activation == 'gelu':
+    elif activation == "gelu":
         return gelu
-    elif activation == 'gelu_fast':
-        deprecation_warning('--activation-fn=gelu_fast has been renamed to gelu_accurate')
+    elif activation == "gelu_fast":
+        deprecation_warning(
+            "--activation-fn=gelu_fast has been renamed to gelu_accurate"
+        )
         return gelu_accurate
-    elif activation == 'gelu_accurate':
+    elif activation == "gelu_accurate":
         return gelu_accurate
-    elif activation == 'tanh':
+    elif activation == "tanh":
         return torch.tanh
-    elif activation == 'linear':
+    elif activation == "linear":
         return lambda x: x
     else:
         raise RuntimeError("--activation-fn {} not supported".format(activation))
@@ -359,12 +366,12 @@ def get_activation_fn(activation: str) -> Callable:
 
 def get_available_activation_fns() -> List:
     return [
-        'relu',
-        'gelu',
-        'gelu_fast',  # deprecated
-        'gelu_accurate',
-        'tanh',
-        'linear',
+        "relu",
+        "gelu",
+        "gelu_fast",  # deprecated
+        "gelu_accurate",
+        "tanh",
+        "linear",
     ]
 
 
@@ -407,7 +414,7 @@ def parse_alignment(line):
     alignments = line.strip().split()
     parsed_alignment = torch.IntTensor(2 * len(alignments))
     for idx, alignment in enumerate(alignments):
-        src_idx, tgt_idx = alignment.split('-')
+        src_idx, tgt_idx = alignment.split("-")
         parsed_alignment[2 * idx] = int(src_idx)
         parsed_alignment[2 * idx + 1] = int(tgt_idx)
     return parsed_alignment
@@ -429,10 +436,15 @@ def extract_hard_alignment(attn, src_sent, tgt_sent, pad, eos):
     alignment = []
     if len(tgt_valid) != 0 and len(src_invalid) < len(src_sent):
         attn_valid = attn[tgt_valid]
-        attn_valid[:, src_invalid] = float('-inf')
+        attn_valid[:, src_invalid] = float("-inf")
         _, src_indices = attn_valid.max(dim=1)
         for tgt_idx, src_idx in zip(tgt_valid, src_indices):
-            alignment.append((src_token_to_word[src_idx.item()] - 1, tgt_token_to_word[tgt_idx.item()] - 1))
+            alignment.append(
+                (
+                    src_token_to_word[src_idx.item()] - 1,
+                    tgt_token_to_word[tgt_idx.item()] - 1,
+                )
+            )
     return alignment
 
 

--- a/fairseq/utils.py
+++ b/fairseq/utils.py
@@ -12,11 +12,13 @@ import sys
 import warnings
 from collections import defaultdict
 from itertools import accumulate
-from typing import Callable, List
+from typing import Callable, Dict, List, Optional
 
 import torch
 import torch.nn.functional as F
 from fairseq.modules import gelu, gelu_accurate
+from fairseq.modules.multihead_attention import MultiheadAttention
+from torch import Tensor
 
 
 def load_ensemble_for_inference(filenames, task, model_arg_overrides=None):
@@ -55,24 +57,22 @@ def move_to_cuda(sample):
     return apply_to_sample(_move_to_cuda, sample)
 
 
-INCREMENTAL_STATE_INSTANCE_ID = defaultdict(lambda: 0)
+INCREMENTAL_STATE_INSTANCE_ID = {}
 
 
-def _get_full_incremental_state_key(module_instance, key):
-    module_name = module_instance.__class__.__name__
-
-    # assign a unique ID to each module instance, so that incremental state is
-    # not shared across module instances
-    if not hasattr(module_instance, "_fairseq_instance_id"):
-        INCREMENTAL_STATE_INSTANCE_ID[module_name] += 1
-        module_instance._fairseq_instance_id = INCREMENTAL_STATE_INSTANCE_ID[
-            module_name
-        ]
-
-    return "{}.{}.{}".format(module_name, module_instance._fairseq_instance_id, key)
+def _get_full_incremental_state_key(
+    module_instance: MultiheadAttention, key: str
+) -> str:
+    return "{}.{}.{}".format(
+        module_instance.module_name, module_instance._fairseq_instance_id, key
+    )
 
 
-def get_incremental_state(module, incremental_state, key):
+def get_incremental_state(
+    module: MultiheadAttention,
+    incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]],
+    key: str,
+) -> Optional[Dict[str, Optional[Tensor]]]:
     """Helper for getting incremental state for an nn.Module."""
     full_key = _get_full_incremental_state_key(module, key)
     if incremental_state is None or full_key not in incremental_state:
@@ -80,7 +80,12 @@ def get_incremental_state(module, incremental_state, key):
     return incremental_state[full_key]
 
 
-def set_incremental_state(module, incremental_state, key, value):
+def set_incremental_state(
+    module: MultiheadAttention,
+    incremental_state: Optional[Dict[str, Dict[str, Optional[Tensor]]]],
+    key: str,
+    value: Dict[str, Optional[Tensor]],
+):
     """Helper for setting incremental state for an nn.Module."""
     if incremental_state is not None:
         full_key = _get_full_incremental_state_key(module, key)
@@ -317,7 +322,7 @@ def import_user_module(args):
             sys.path.pop(0)
 
 
-def softmax(x, dim, onnx_trace=False):
+def softmax(x, dim: int, onnx_trace: bool = False):
     if onnx_trace:
         return F.softmax(x.float(), dim=dim)
     else:

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import unittest
+
+import torch
+from fairseq.modules import multihead_attention
+
+
+class TestExportModels(unittest.TestCase):
+    def test_export_multihead_attention(self):
+        module = multihead_attention.MultiheadAttention(embed_dim=8, num_heads=2)
+        torch.jit.script(module)

--- a/tests/test_reproducibility.py
+++ b/tests/test_reproducibility.py
@@ -71,7 +71,7 @@ class TestReproducibility(unittest.TestCase):
         self._test_reproducibility('test_reproducibility_fp16', [
             '--fp16',
             '--fp16-init-scale', '4096',
-        ], delta=0.01)
+        ], delta=0.011)
 
     @unittest.skipIf(not torch.cuda.is_available(), 'test requires a GPU')
     def test_reproducibility_memory_efficient_fp16(self):


### PR DESCRIPTION
Summary:
Make fairseq MultiheadAttention scriptable. Looking for feedbacks.

1. Add types
2. Move incremental state management logic from util functions to initializers. TorchScript in general doesn't support global dict. As a result modules with multihead attention in it would assign itself fairseq_instance_id in the initializer.
3. There might be opportunities to make assertions and annotations cleaner.

Differential Revision: D18772594

