### PR TITLE
Update README for apex

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ and [RoBERTa](https://pytorch.org/hub/pytorch_fairseq_roberta/) for more example
 * [PyTorch](http://pytorch.org/) version >= 1.2.0
 * Python version >= 3.6
 * For training new models, you'll also need an NVIDIA GPU and [NCCL](https://github.com/NVIDIA/nccl)
-* **For faster training** install NVIDIA's [apex](https://github.com/NVIDIA/apex) library with the `--cuda_ext` option
+* **For faster training** install NVIDIA's [apex](https://github.com/NVIDIA/apex) library with the `--cuda_ext` and `--deprecated_fused_adam` options
 
 To install fairseq:
 ```bash


### PR DESCRIPTION
Recent releases of apex removed the `fused_adam_cuda` function used in https://github.com/pytorch/fairseq/blob/3f4fc5016334255d6908b20202267ca0b0287335/fairseq/optim/adam.py#L220. Users need to use the `--deprecated_fused_adam` option to isntall `fused_adam_cuda`

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?
Fixes # (issue).

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
