### PR TITLE
Use mask token inplace of unk token in lev transformer

### DIFF
--- a/fairseq/models/nat/levenshtein_transformer.py
+++ b/fairseq/models/nat/levenshtein_transformer.py
@@ -33,6 +33,10 @@ from .levenshtein_utils import (
 @register_model("levenshtein_transformer")
 class LevenshteinTransformerModel(FairseqNATModel):
 
+    def __init__(self, args, encoder, decoder):
+        super().__init__(args, encoder, decoder)
+        self.mask = self.tgt_dict.index('<mask>')
+
     @property
     def allow_length_beam(self):
         return False
@@ -276,7 +280,6 @@ class LevenshteinTransformerDecoder(FairseqNATDecoder):
         )
         self.dictionary = dictionary
         self.bos = dictionary.bos()
-        self.mask = dictionary.index('<mask>')
         self.eos = dictionary.eos()
         self.sampling_for_deletion = getattr(args, "sampling_for_deletion", False)
         self.embed_mask_ins = Embedding(256, self.output_embed_dim * 2, None)


### PR DESCRIPTION
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you write any new necessary tests?
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?

## What does this PR do?
Don't merge this PR yet, this is a breaking change.

Instead of using `<unk>` token as placeholders in Levenstein transformer,
this PR changes that to the `<mask>` token.

The breaking portion is that lev transformer models would not be backward compatible with
`fairseq-0.9` due to the missing `<mask>` token embedding, a dirty solution would be to use existing `<unk>` token embeddings as a drop-in.

The current changes are the minimum required code edits.
However this PR is not complete, at least 2 other changes are suggested:
- Refactor `levenshtein_utils.py`
- Add `unk_penalty` to `iterative_refinement_generator`
