### PR TITLE
Fix padding_idx logical error in Adaptive Input

### DIFF
--- a/fairseq/modules/adaptive_input.py
+++ b/fairseq/modules/adaptive_input.py
@@ -39,11 +39,12 @@ class AdaptiveInput(nn.Module):
             size = self.cutoff[i] - prev
             dim = int(initial_dim // (factor ** i))
             seq = nn.Sequential(
-                nn.Embedding(size, dim, padding_idx),
+                nn.Embedding(size, dim, self.padding_idx),
                 nn.Linear(dim, output_dim, bias=False)
             )
             self.embeddings.append(seq)
             self.padding_idx = None
+        self.padding_idx = padding_idx
 
         def init_weights(m):
             if isinstance(m, nn.Embedding):

--- a/fairseq/modules/adaptive_input.py
+++ b/fairseq/modules/adaptive_input.py
@@ -43,6 +43,7 @@ class AdaptiveInput(nn.Module):
                 nn.Linear(dim, output_dim, bias=False)
             )
             self.embeddings.append(seq)
+            self.padding_idx = None
 
         def init_weights(m):
             if isinstance(m, nn.Embedding):


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?

I think if we keep pass **padding index of vocabulary** as `padding_idx` to adaptive embedding layers, 
there will be no chance to train some words.

e.g. If `cut_off` is (20000,60000) and vocab is larger than 60000, 
we can't learn[**20,000+padding_idx**]th word and [**60,000+padding_idx**]th word.
Because those words' ids will be **padding_idx** by subtraction logic and eventually get zero tensors.

So, I changed `self.padding_idx` to `None` after assign vocab's `padding_idx` 
**for the first time at head embedding representation**.