### PR TITLE
Fix logging of training sets (fixes #1632)

### DIFF
--- a/fairseq/metrics.py
+++ b/fairseq/metrics.py
@@ -34,19 +34,19 @@ _active_aggregators_cnt["default"] = 1
 
 
 @contextlib.contextmanager
-def aggregate(name: Optional[str] = None, exclusive: bool = False):
+def aggregate(name: Optional[str] = None, new_root: bool = False):
     """Context manager to aggregate metrics under a given name.
 
-    Aggregations can be nested. If *exclusive* is ``False``, then logged
+    Aggregations can be nested. If *new_root* is ``False``, then logged
     metrics will be recorded along the entire stack of nested
-    aggregators, including a global "default" aggregator. If *exclusive*
-    is ``True``, then only the most recent aggregator will be used.
+    aggregators, including a global "default" aggregator. If *new_root*
+    is ``True``, then this aggregator will be the root of a new
+    aggregation stack, thus bypassing any parent aggregators.
 
     Note that aggregation contexts are uniquely identified by their
     *name* (e.g., train, valid). Creating a context with an existing
     name will reuse the corresponding :class:`MetersDict` instance.
-    If no name is given then a temporary aggregator will be created
-    and reset when the context manager exits.
+    If no name is given, then a temporary aggregator will be created.
 
     Usage::
 
@@ -62,8 +62,8 @@ def aggregate(name: Optional[str] = None, exclusive: bool = False):
     Args:
         name (str): name of the aggregation. Defaults to a
             random/temporary name if not given explicitly.
-        exclusive (bool): only log to the most recent aggregation
-            context, instead of all nested aggregations.
+        new_root (bool): make this aggregation the root of a new
+            aggregation stack.
     """
     if name is None:
         # generate a temporary name
@@ -74,7 +74,7 @@ def aggregate(name: Optional[str] = None, exclusive: bool = False):
         assert name != "default"
         agg = _aggregators.setdefault(name, MetersDict())
 
-    if exclusive:
+    if new_root:
         backup_aggregators = _active_aggregators.copy()
         _active_aggregators.clear()
         backup_aggregators_cnt = _active_aggregators_cnt.copy()
@@ -89,7 +89,7 @@ def aggregate(name: Optional[str] = None, exclusive: bool = False):
     if _active_aggregators_cnt[name] == 0 and name in _active_aggregators:
         del _active_aggregators[name]
 
-    if exclusive:
+    if new_root:
         _active_aggregators.clear()
         _active_aggregators.update(backup_aggregators)
         _active_aggregators_cnt.clear()

--- a/fairseq_cli/train.py
+++ b/fairseq_cli/train.py
@@ -141,6 +141,7 @@ def should_stop_early(args, valid_loss):
         return should_stop_early.num_runs > args.patience
 
 
+@metrics.aggregate('train')
 def train(args, trainer, task, epoch_itr):
     """Train the model for one epoch."""
     # Initialize data iterator
@@ -163,31 +164,30 @@ def train(args, trainer, task, epoch_itr):
 
     valid_subsets = args.valid_subset.split(',')
     max_update = args.max_update or math.inf
-    with metrics.aggregate() as agg:
-        for samples in progress:
-            log_output = trainer.train_step(samples)
-            num_updates = trainer.get_num_updates()
-            if log_output is None:
-                continue
+    for samples in progress:
+        log_output = trainer.train_step(samples)
+        num_updates = trainer.get_num_updates()
+        if log_output is None:
+            continue
 
-            # log mid-epoch stats
-            stats = get_training_stats(agg.get_smoothed_values())
-            progress.log(stats, tag='train', step=num_updates)
+        # log mid-epoch stats
+        stats = get_training_stats(metrics.get_smoothed_values('train'))
+        progress.log(stats, tag='train', step=num_updates)
 
-            if (
-                not args.disable_validation
-                and args.save_interval_updates > 0
-                and num_updates % args.save_interval_updates == 0
-                and num_updates > 0
-            ):
-                valid_losses = validate(args, trainer, task, epoch_itr, valid_subsets)
-                checkpoint_utils.save_checkpoint(args, trainer, epoch_itr, valid_losses[0])
+        if (
+            not args.disable_validation
+            and args.save_interval_updates > 0
+            and num_updates % args.save_interval_updates == 0
+            and num_updates > 0
+        ):
+            valid_losses = validate(args, trainer, task, epoch_itr, valid_subsets)
+            checkpoint_utils.save_checkpoint(args, trainer, epoch_itr, valid_losses[0])
 
-            if num_updates >= max_update:
-                break
+        if num_updates >= max_update:
+            break
 
     # log end-of-epoch stats
-    stats = get_training_stats(agg.get_smoothed_values())
+    stats = get_training_stats(metrics.get_smoothed_values('train'))
     progress.print(stats, tag='train', step=num_updates)
 
     # reset epoch-level meters
@@ -232,10 +232,9 @@ def validate(args, trainer, task, epoch_itr, subsets):
             no_progress_bar='simple'
         )
 
-        # reset validation meters
-        metrics.reset_meters('valid')
-
-        with metrics.aggregate() as agg:
+        # create a new root metrics aggregator so validation metrics
+        # don't pollute other aggregators (e.g., train meters)
+        with metrics.aggregate(new_root=True) as agg:
             for sample in progress:
                 trainer.valid_step(sample)
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,78 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+import uuid
+
+from fairseq import metrics
+
+
+class TestMetrics(unittest.TestCase):
+
+    def test_nesting(self):
+        with metrics.aggregate() as a:
+            metrics.log_scalar('loss', 1)
+            with metrics.aggregate() as b:
+                metrics.log_scalar('loss', 2)
+
+        self.assertEqual(a.get_smoothed_values()['loss'], 1.5)
+        self.assertEqual(b.get_smoothed_values()['loss'], 2)
+
+    def test_new_root(self):
+        with metrics.aggregate() as a:
+            metrics.log_scalar('loss', 1)
+            with metrics.aggregate(new_root=True) as b:
+                metrics.log_scalar('loss', 2)
+
+        self.assertEqual(a.get_smoothed_values()['loss'], 1)
+        self.assertEqual(b.get_smoothed_values()['loss'], 2)
+
+    def test_nested_new_root(self):
+        with metrics.aggregate() as layer1:
+            metrics.log_scalar('loss', 1)
+            with metrics.aggregate(new_root=True) as layer2:
+                metrics.log_scalar('loss', 2)
+                with metrics.aggregate() as layer3:
+                    metrics.log_scalar('loss', 3)
+                    with metrics.aggregate(new_root=True) as layer4:
+                        metrics.log_scalar('loss', 4)
+            metrics.log_scalar('loss', 1.5)
+
+        self.assertEqual(layer4.get_smoothed_values()['loss'], 4)
+        self.assertEqual(layer3.get_smoothed_values()['loss'], 3)
+        self.assertEqual(layer2.get_smoothed_values()['loss'], 2.5)
+        self.assertEqual(layer1.get_smoothed_values()['loss'], 1.25)
+
+    def test_named(self):
+        name = str(uuid.uuid4())
+        metrics.reset_meters(name)
+
+        with metrics.aggregate(name):
+            metrics.log_scalar('loss', 1)
+
+        metrics.log_scalar('loss', 3)
+
+        with metrics.aggregate(name):
+            metrics.log_scalar('loss', 2)
+
+        self.assertEqual(metrics.get_smoothed_values(name)['loss'], 1.5)
+
+    def test_nested_duplicate_names(self):
+        name = str(uuid.uuid4())
+        metrics.reset_meters(name)
+
+        with metrics.aggregate(name):
+            metrics.log_scalar('loss', 1)
+            with metrics.aggregate() as other:
+                with metrics.aggregate(name):
+                    metrics.log_scalar('loss', 2)
+            metrics.log_scalar('loss', 6)
+
+        self.assertEqual(metrics.get_smoothed_values(name)['loss'], 3)
+        self.assertEqual(other.get_smoothed_values()['loss'], 2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
* fix: mid-epoch validation metrics were previously polluting training metrics
* fix: mid-epoch metrics were not properly saved/restored in checkpoints
* added tests, both for metrics and for mid-epoch reproducibility