### PR TITLE
already_numberized option for binarizer

### DIFF
--- a/fairseq/binarizer.py
+++ b/fairseq/binarizer.py
@@ -3,8 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from collections import Counter
 import os
+from collections import Counter
 
 from fairseq.tokenizer import tokenize_line
 
@@ -20,10 +20,17 @@ def safe_readline(f):
 
 
 class Binarizer:
-
     @staticmethod
-    def binarize(filename, dict, consumer, tokenize=tokenize_line, append_eos=True, reverse_order=False,
-                 offset=0, end=-1):
+    def binarize(
+        filename,
+        dict,
+        consumer,
+        tokenize=tokenize_line,
+        append_eos=True,
+        reverse_order=False,
+        offset=0,
+        end=-1,
+    ):
         nseq, ntok = 0, 0
         replaced = Counter()
 
@@ -31,7 +38,7 @@ class Binarizer:
             if idx == dict.unk_index and word != dict.unk_word:
                 replaced.update([word])
 
-        with open(filename, 'r', encoding='utf-8') as f:
+        with open(filename, "r", encoding="utf-8") as f:
             f.seek(offset)
             # next(f) breaks f.tell(), hence readline() must be used
             line = safe_readline(f)
@@ -39,24 +46,29 @@ class Binarizer:
                 if end > 0 and f.tell() > end:
                     break
                 ids = dict.encode_line(
-                        line=line,
-                        line_tokenizer=tokenize,
-                        add_if_not_exist=False,
-                        consumer=replaced_consumer,
-                        append_eos=append_eos,
-                        reverse_order=reverse_order,
+                    line=line,
+                    line_tokenizer=tokenize,
+                    add_if_not_exist=False,
+                    consumer=replaced_consumer,
+                    append_eos=append_eos,
+                    reverse_order=reverse_order,
                 )
                 nseq += 1
                 ntok += len(ids)
                 consumer(ids)
                 line = f.readline()
-        return {'nseq': nseq, 'nunk': sum(replaced.values()), 'ntok': ntok, 'replaced': replaced}
+        return {
+            "nseq": nseq,
+            "nunk": sum(replaced.values()),
+            "ntok": ntok,
+            "replaced": replaced,
+        }
 
     @staticmethod
     def binarize_alignments(filename, alignment_parser, consumer, offset=0, end=-1):
         nseq = 0
 
-        with open(filename, 'r') as f:
+        with open(filename, "r") as f:
             f.seek(offset)
             line = safe_readline(f)
             while line:
@@ -66,11 +78,11 @@ class Binarizer:
                 nseq += 1
                 consumer(ids)
                 line = f.readline()
-        return {'nseq': nseq}
+        return {"nseq": nseq}
 
     @staticmethod
     def find_offsets(filename, num_chunks):
-        with open(filename, 'r', encoding='utf-8') as f:
+        with open(filename, "r", encoding="utf-8") as f:
             size = os.fstat(f.fileno()).st_size
             chunk_size = size // num_chunks
             offsets = [0 for _ in range(num_chunks + 1)]

--- a/fairseq/binarizer.py
+++ b/fairseq/binarizer.py
@@ -7,6 +7,7 @@ import os
 from collections import Counter
 
 from fairseq.tokenizer import tokenize_line
+import torch
 
 
 def safe_readline(f):
@@ -30,6 +31,7 @@ class Binarizer:
         reverse_order=False,
         offset=0,
         end=-1,
+        already_numberized=False,
     ):
         nseq, ntok = 0, 0
         replaced = Counter()
@@ -45,14 +47,23 @@ class Binarizer:
             while line:
                 if end > 0 and f.tell() > end:
                     break
-                ids = dict.encode_line(
-                    line=line,
-                    line_tokenizer=tokenize,
-                    add_if_not_exist=False,
-                    consumer=replaced_consumer,
-                    append_eos=append_eos,
-                    reverse_order=reverse_order,
-                )
+                if already_numberized:
+                    ind_strings = line.strip().split()
+                    inds = [int(ind) for ind in ind_strings]
+                    if reverse_order:
+                        inds.reverse()
+                    if append_eos:
+                        inds.append(dict.eos())
+                    inds = torch.IntTensor(inds)
+                else:
+                    ids = dict.encode_line(
+                        line=line,
+                        line_tokenizer=tokenize,
+                        add_if_not_exist=False,
+                        consumer=replaced_consumer,
+                        append_eos=append_eos,
+                        reverse_order=reverse_order,
+                    )
                 nseq += 1
                 ntok += len(ids)
                 consumer(ids)


### PR DESCRIPTION
Summary:
Provide an option to binarize numberized text files, where the lines consist of space-separated decimal string representations of the underlying dictionary indices.

Faceboook:

Production training currently works by producing files of this type using the VocabProcessor mechanism, and this approach seemed the least disruptive (though another possibility would be to subclass `Binarizer` in an `fb_` file).

Differential Revision: D19704131

