### PR TITLE
fetch pyproject.toml for building cython codes without pre-installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "cython"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - #1060 
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
  - I think it is not needed to update the docs
- [ ] Did you write any new necessary tests? 
  - Cannot write test code for installing package, but I got test on my forked github repository and local system
    - ex) pip install git+https://github.com/AppleHolic/fairseq@fetch_build_toml

## What does this PR do?
Fixes #1060 

Hello, I got an error to install fairseq when I install another repository that has an depandancy on fairseq. There is no problem when the cython is already installed, but I wanna solve this problem with [PEP](https://www.python.org/dev/peps/pep-0518/). 

This PR gives build-ability cython extension on setup time without pre-installation of cython. And I tested on two cases (install from github, install from local directory). 


## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃!
