### PR TITLE
split_paths to support manifold path

### DIFF
--- a/fairseq/tasks/cross_lingual_lm.py
+++ b/fairseq/tasks/cross_lingual_lm.py
@@ -22,7 +22,7 @@ from fairseq.data import (
 from fairseq.data.legacy.masked_lm_dataset import MaskedLMDataset
 from fairseq.data.multi_corpus_sampled_dataset import MultiCorpusSampledDataset
 from fairseq.tasks import FairseqTask, register_task
-
+from fairseq import utils
 
 logger = logging.getLogger(__name__)
 
@@ -100,7 +100,7 @@ class CrossLingualLMTask(FairseqTask):
     def _load_single_lang_dataset(self, split, epoch):
         loaded_datasets = []
 
-        paths = self.args.data.split(os.pathsep)
+        paths = utils.split_paths(self.args.data)
         assert len(paths) > 0
         data_path = paths[epoch % len(paths)]
 
@@ -165,5 +165,5 @@ class CrossLingualLMTask(FairseqTask):
 
         self.datasets[split] = MultiCorpusSampledDataset(dataset_map)
         logger.info('{} {} {} examples'.format(
-            self.args.data.split(os.pathsep)[epoch], split, len(self.datasets[split]))
+            utils.split_paths(self.args.data)[epoch], split, len(self.datasets[split]))
         )

--- a/fairseq/tasks/denoising.py
+++ b/fairseq/tasks/denoising.py
@@ -17,6 +17,7 @@ from fairseq.data import (
 )
 from fairseq.data.encoders.utils import get_whole_word_mask
 from fairseq.tasks import FairseqTask, register_task
+from fairseq import utils
 
 
 logger = logging.getLogger(__name__)
@@ -110,7 +111,7 @@ class DenoisingTask(FairseqTask):
             split (str): name of the split (e.g., train, valid, test)
         """
 
-        paths = self.args.data.split(os.pathsep)
+        paths = utils.split_paths(self.args.data)
         assert len(paths) > 0
         data_path = paths[epoch % len(paths)]
         split_path = os.path.join(data_path, split)

--- a/fairseq/tasks/language_modeling.py
+++ b/fairseq/tasks/language_modeling.py
@@ -110,7 +110,7 @@ class LanguageModelingTask(FairseqTask):
         dictionary = None
         output_dictionary = None
         if args.data:
-            paths = args.data.split(os.pathsep)
+            paths = utils.split_paths(args.data)
             assert len(paths) > 0
             dictionary = Dictionary.load(os.path.join(paths[0], "dict.txt"))
             logger.info("dictionary: {} types".format(len(dictionary)))
@@ -154,7 +154,7 @@ class LanguageModelingTask(FairseqTask):
         Args:
             split (str): name of the split (e.g., train, valid, test)
         """
-        paths = self.args.data.split(os.pathsep)
+        paths = utils.split_paths(self.args.data)
         assert len(paths) > 0
 
         data_path = paths[epoch % len(paths)]

--- a/fairseq/tasks/legacy_masked_lm.py
+++ b/fairseq/tasks/legacy_masked_lm.py
@@ -21,6 +21,7 @@ from fairseq.data.legacy.block_pair_dataset import BlockPairDataset
 from fairseq.data.legacy.masked_lm_dataset import MaskedLMDataset
 from fairseq.data.legacy.masked_lm_dictionary import BertDictionary
 from fairseq.tasks import FairseqTask, register_task
+from fairseq import utils
 
 
 logger = logging.getLogger(__name__)
@@ -70,7 +71,7 @@ class LegacyMaskedLMTask(FairseqTask):
     def setup_task(cls, args, **kwargs):
         """Setup the task.
         """
-        paths = args.data.split(os.pathsep)
+        paths = utils.split_paths(args.data)
         assert len(paths) > 0
         dictionary = BertDictionary.load(os.path.join(paths[0], 'dict.txt'))
         logger.info('dictionary: {} types'.format(len(dictionary)))
@@ -84,7 +85,7 @@ class LegacyMaskedLMTask(FairseqTask):
         """
         loaded_datasets = []
 
-        paths = self.args.data.split(os.pathsep)
+        paths = utils.split_paths(self.args.data)
         assert len(paths) > 0
         data_path = paths[epoch % len(paths)]
         logger.info("data_path", data_path)

--- a/fairseq/tasks/masked_lm.py
+++ b/fairseq/tasks/masked_lm.py
@@ -23,6 +23,7 @@ from fairseq.data import (
 )
 from fairseq.tasks import FairseqTask, register_task
 from fairseq.data.encoders.utils import get_whole_word_mask
+from fairseq import utils
 
 
 logger = logging.getLogger(__name__)
@@ -68,7 +69,7 @@ class MaskedLMTask(FairseqTask):
 
     @classmethod
     def setup_task(cls, args, **kwargs):
-        paths = args.data.split(os.pathsep)
+        paths = utils.split_paths(args.data)
         assert len(paths) > 0
         dictionary = Dictionary.load(os.path.join(paths[0], 'dict.txt'))
         logger.info('dictionary: {} types'.format(len(dictionary)))
@@ -80,7 +81,7 @@ class MaskedLMTask(FairseqTask):
         Args:
             split (str): name of the split (e.g., train, valid, test)
         """
-        paths = self.args.data.split(os.pathsep)
+        paths = utils.split_paths(self.args.data)
         assert len(paths) > 0
         data_path = paths[epoch % len(paths)]
         split_path = os.path.join(data_path, split)

--- a/fairseq/tasks/multilingual_masked_lm.py
+++ b/fairseq/tasks/multilingual_masked_lm.py
@@ -27,6 +27,7 @@ from fairseq.data import (
     TokenBlockDataset,
 )
 from fairseq.tasks import FairseqTask, register_task
+from fairseq import utils
 
 
 logger = logging.getLogger(__name__)
@@ -74,7 +75,7 @@ class MultiLingualMaskedLMTask(FairseqTask):
 
     @classmethod
     def setup_task(cls, args, **kwargs):
-        paths = args.data.split(os.pathsep)
+        paths = utils.split_paths(args.data)
         assert len(paths) > 0
         dictionary = Dictionary.load(os.path.join(paths[0], 'dict.txt'))
         logger.info('dictionary: {} types'.format(len(dictionary)))
@@ -121,7 +122,7 @@ class MultiLingualMaskedLMTask(FairseqTask):
         Args:
             split (str): name of the split (e.g., train, valid, test)
         """
-        paths = self.args.data.split(os.pathsep)
+        paths = utils.split_paths(self.args.data)
         assert len(paths) > 0
         data_path = paths[epoch % len(paths)]
 

--- a/fairseq/tasks/multilingual_translation.py
+++ b/fairseq/tasks/multilingual_translation.py
@@ -20,7 +20,7 @@ from fairseq.models import FairseqMultiModel
 from fairseq.tasks.translation import load_langpair_dataset
 
 from . import FairseqTask, register_task
-
+from fairseq import utils
 
 logger = logging.getLogger(__name__)
 
@@ -135,7 +135,7 @@ class MultilingualTranslationTask(FairseqTask):
         # load dictionaries
         dicts = OrderedDict()
         for lang in sorted_langs:
-            paths = args.data.split(os.pathsep)
+            paths = utils.split_paths(args.data)
             assert len(paths) > 0
             dicts[lang] = Dictionary.load(os.path.join(paths[0], 'dict.{}.txt'.format(lang)))
             if len(dicts) > 0:
@@ -190,7 +190,7 @@ class MultilingualTranslationTask(FairseqTask):
     def load_dataset(self, split, epoch=0, **kwargs):
         """Load a dataset split."""
 
-        paths = self.args.data.split(os.pathsep)
+        paths = utils.split_paths(self.args.data)
         assert len(paths) > 0
         data_path = paths[epoch % len(paths)]
 

--- a/fairseq/tasks/semisupervised_translation.py
+++ b/fairseq/tasks/semisupervised_translation.py
@@ -23,7 +23,7 @@ from fairseq.sequence_generator import SequenceGenerator
 
 from .multilingual_translation import MultilingualTranslationTask
 from . import register_task
-
+from fairseq import utils
 
 logger = logging.getLogger(__name__)
 
@@ -139,7 +139,7 @@ class SemisupervisedTranslationTask(MultilingualTranslationTask):
     def load_dataset(self, split, epoch=0, **kwargs):
         """Load a dataset split."""
 
-        paths = self.args.data.split(os.pathsep)
+        paths = utils.split_paths(self.args.data)
         assert len(paths) > 0
         data_path = paths[epoch % len(paths)]
 

--- a/fairseq/tasks/translation.py
+++ b/fairseq/tasks/translation.py
@@ -199,7 +199,7 @@ class TranslationTask(FairseqTask):
         args.left_pad_source = options.eval_bool(args.left_pad_source)
         args.left_pad_target = options.eval_bool(args.left_pad_target)
 
-        paths = args.data.split(os.pathsep)
+        paths = utils.split_paths(args.data)
         assert len(paths) > 0
         # find language pair automatically
         if args.source_lang is None or args.target_lang is None:
@@ -224,7 +224,7 @@ class TranslationTask(FairseqTask):
         Args:
             split (str): name of the split (e.g., train, valid, test)
         """
-        paths = self.args.data.split(os.pathsep)
+        paths = utils.split_paths(self.args.data)
         assert len(paths) > 0
         data_path = paths[epoch % len(paths)]
 

--- a/fairseq/tasks/translation_lev.py
+++ b/fairseq/tasks/translation_lev.py
@@ -10,7 +10,7 @@ import torch
 from fairseq.utils import new_arange
 from fairseq.tasks import register_task
 from fairseq.tasks.translation import TranslationTask, load_langpair_dataset
-
+from fairseq import utils
 
 @register_task('translation_lev')
 class TranslationLevenshteinTask(TranslationTask):
@@ -35,7 +35,7 @@ class TranslationLevenshteinTask(TranslationTask):
         Args:
             split (str): name of the split (e.g., train, valid, test)
         """
-        paths = self.args.data.split(os.pathsep)
+        paths = utils.split_paths(self.args.data)
         assert len(paths) > 0
         data_path = paths[epoch % len(paths)]
 

--- a/fairseq/utils.py
+++ b/fairseq/utils.py
@@ -26,6 +26,10 @@ from torch import Tensor
 logger = logging.getLogger(__name__)
 
 
+def split_paths(paths: str) -> List[str]:
+    return paths.split(os.pathsep) if "manifold://" not in paths else paths.split("|")
+
+
 def load_ensemble_for_inference(filenames, task, model_arg_overrides=None):
     from fairseq import checkpoint_utils
 


### PR DESCRIPTION
Summary: Manifold path (of format manifold://...) contains ":" which was used as delimiter in fairseq. Add support for splitting manifold paths with "|" as delimiter, as we currently do in pytorch_translate.

Differential Revision: D19963376

