### PR TITLE
fix epoch check for curriculum learning

### DIFF
--- a/fairseq_cli/train.py
+++ b/fairseq_cli/train.py
@@ -148,7 +148,7 @@ def train(args, trainer, task, epoch_itr):
     # Initialize data iterator
     itr = epoch_itr.next_epoch_itr(
         fix_batches_to_gpus=args.fix_batches_to_gpus,
-        shuffle=(epoch_itr.epoch > args.curriculum),
+        shuffle=(epoch_itr.epoch >= args.curriculum),
     )
     update_freq = (
         args.update_freq[epoch_itr.epoch - 1]


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- Did you write any new necessary tests?  

## What does this PR do?
Fixes epoch check for curriculum learning. `epoch_itr.epoch` has not been incremented before calling `next_epoch_itr()`. So the check for curriculum learning should look like the proposed fix.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
