### PR TITLE
Fix a crash in Early Stopping when --validate-interval is greater than 1

### DIFF
--- a/fairseq_cli/train.py
+++ b/fairseq_cli/train.py
@@ -126,6 +126,9 @@ def main(args, init_distributed=False):
 
 
 def should_stop_early(args, valid_loss):
+    # skip check if no validation was done in the current epoch
+    if valid_loss is None:
+        return False
     if args.patience <= 0:
         return False
 


### PR DESCRIPTION
Summary:
When --validate-interval is set to greater than 1, the validation loss is set to None for those epochs where no validation was done.

This caused a crash in Early Stopping if the "--patience" option was set to a positive value. The reason is that `valid_loss` is compared with `prev_best`, resulting a crash when None is compared to a float:
```
TypeError: '>' not supported between instances of 'NoneType' and 'float'
```

A simple check is added to the should_stop_early() method which skips checking if no validation is done in the current epoch.

Reviewed By: myleott

Differential Revision: D20318486

