### PR TITLE
Fairseq evaluate integration

### DIFF
--- a/fairseq/file_io.py
+++ b/fairseq/file_io.py
@@ -13,7 +13,7 @@ from typing import List, Optional
 try:
     from fvcore.common.file_io import PathManager as FVCorePathManager
 
-except (ImportError, ModuleNotFoundError):
+except ImportError:
     FVCorePathManager = None
 
 
@@ -60,9 +60,9 @@ class PathManager:
         return shutil.copyfile(src_path, dst_path)
 
     @staticmethod
-    def get_local_path(path: str) -> str:
+    def get_local_path(path: str, **kwargs) -> str:
         if FVCorePathManager:
-            return FVCorePathManager.get_local_path(path)
+            return FVCorePathManager.get_local_path(path, **kwargs)
         return path
 
     @staticmethod

--- a/fairseq_cli/generate.py
+++ b/fairseq_cli/generate.py
@@ -66,7 +66,7 @@ def _main(args, output_file):
     # Load ensemble
     logger.info('loading model(s) from {}'.format(args.path))
     models, _model_args = checkpoint_utils.load_model_ensemble(
-        args.path.split(os.pathsep),
+        utils.split_paths(args.path),
         arg_overrides=eval(args.model_overrides),
         task=task,
     )


### PR DESCRIPTION
Summary:
Create a separate workflow for fairseq native evaluation with a trained checkpoint. This is developed from fairseq/evaluate with simplification, refactoring and manifold migration. If fairseq folks are interested we could unify with their implementation.

preprocess_and_eval() takes in raw test data, lowercase, preprocess and get lc bleu score using fairseq generate.

Since test data is still on gluster and yoda related operators haven't been migrated to Manifold, we are still having sporadic gluster usage across the file.

Integration to base training, right after ensemble_and_sweep will be in next diff.

Fairseq side changes only include ones to support manifold path. cc myleott

Differential Revision: D20194073

