### PR TITLE
Set perplexity to inf in log stats in case of overflow error

### DIFF
--- a/fairseq/utils.py
+++ b/fairseq/utils.py
@@ -346,7 +346,10 @@ def log_softmax(x, dim: int, onnx_trace: bool = False):
 def get_perplexity(loss, round=2, base=2):
     if loss is None:
         return 0.
-    return safe_round(base**loss, round)
+    try:
+        return safe_round(base ** loss, round)
+    except OverflowError:
+        return float('inf')
 
 
 def deprecation_warning(message, stacklevel=3):


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?
Fixes #1833

Example output after this update:
```
2020-03-12 15:39:26 | WARNING | root | NaN or Inf found in input tensor.
2020-03-12 15:39:26 | INFO | train | epoch 001 | loss 69041.9 | nll_loss 6820 | wps 12712 | ups 6.53 | wpb 1640 | bsz 162 | num_updates 2 | lr 1e-05 | gnorm 2603.12 | loss_scale 16 | train_wall 1 | ppl inf | wall 1
/SFS/user/wp/prihodad/git/fairseq/fairseq/utils.py:351: RuntimeWarning: overflow encountered in power
  return safe_round(np.power(base, loss), round)
2020-03-12 15:39:26 | WARNING | root | NaN or Inf found in input tensor.
2020-03-12 15:39:26 | INFO | valid | epoch 001 | valid on 'valid' subset | loss 71135.5 | nll_loss 7034 | wps 0 | wpb 1699 | bsz 168 | ppl inf | num_updates 2

```
