### PR TITLE
Fix boundary condition in `--patience`

### DIFF
--- a/fairseq_cli/train.py
+++ b/fairseq_cli/train.py
@@ -138,7 +138,7 @@ def should_stop_early(args, valid_loss):
         return False
     else:
         should_stop_early.num_runs += 1
-        return should_stop_early.num_runs > args.patience
+        return should_stop_early.num_runs >= args.patience
 
 
 @metrics.aggregate('train')


### PR DESCRIPTION
When `--patience=1`, we should stop as soon as the validation loss decreases.