### PR TITLE
Fix MHA and LayerNorm on devices other than cuda:0 (fixes #1860)

### DIFF
--- a/fairseq/modules/layer_norm.py
+++ b/fairseq/modules/layer_norm.py
@@ -16,7 +16,8 @@ try:
     class FusedLayerNorm(_FusedLayerNorm):
         @torch.jit.unused
         def forward(self, x):
-            return super().forward(x)
+            with torch.cuda.device(x.device):
+                return super().forward(x)
 
 except ImportError:
     has_fused_layernorm = False

--- a/fairseq/modules/multihead_attention.py
+++ b/fairseq/modules/multihead_attention.py
@@ -378,17 +378,18 @@ class MultiheadAttention(nn.Module):
         # leaves the frame, there will be a time when prev or current
         # is None
         elif prev_key_padding_mask is not None:
-
-            filler = torch.zeros(batch_size, src_len - prev_key_padding_mask.size(1))
-            if prev_key_padding_mask.is_cuda:
-                filler = filler.cuda()
+            filler = torch.zeros(
+                (batch_size, src_len - prev_key_padding_mask.size(1)),
+                device=prev_key_padding_mask.device,
+            )
             new_key_padding_mask = torch.cat(
                 [prev_key_padding_mask.float(), filler.float()], dim=1
             )
         elif key_padding_mask is not None:
-            filler = torch.zeros(batch_size, src_len - key_padding_mask.size(1))
-            if key_padding_mask.is_cuda:
-                filler = filler.cuda()
+            filler = torch.zeros(
+                (batch_size, src_len - key_padding_mask.size(1)),
+                device=key_padding_mask.device,
+            )
             new_key_padding_mask = torch.cat(
                 [filler.float(), key_padding_mask.float()], dim=1
             )


### PR DESCRIPTION
Fixes #1860

This also includes a fix required for LayerNorm due to a bug in apex: https://github.com/NVIDIA/apex/issues/770