### PR TITLE
Fix dummy batch logic in trainer

### DIFF
--- a/fairseq/trainer.py
+++ b/fairseq/trainer.py
@@ -340,12 +340,13 @@ class Trainer(object):
                 else:
                     raise e
 
-        if is_dummy_batch:
-            sample_size *= 0.  # multiply by 0 to preserve device
         if torch.is_tensor(sample_size):
             sample_size = sample_size.float()
         else:
             sample_size = float(sample_size)
+
+        if is_dummy_batch:
+            sample_size *= 0.  # multiply by 0 to preserve device
 
         # gather logging outputs from all replicas
         if self._sync_stats():


### PR DESCRIPTION
We want to wait until `sample_size` is a float before applying dummy batch logic.