### PR TITLE
changes to make mbart work (#1109)

### DIFF
--- a/fairseq/tasks/multilingual_denoising.py
+++ b/fairseq/tasks/multilingual_denoising.py
@@ -54,9 +54,6 @@ class MultilingualDenoisingTask(DenoisingTask):
             ])
         else:
             languages = args.langs.split(',')
-            for name in languages:
-                assert os.path.exists(os.path.join(data_path, name)), \
-                    "{} does not exist".format(os.path.join(data_path, name))
 
         if args.add_lang_token:
             for lang in languages:


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/fairinternal/fairseq-py/pull/1109

Pull Request resolved: https://github.com/facebookresearch/pytext/pull/1289

First remove the assertion since when I load the model for fine-tuning I don't necessarily have all the language directories on my data.
I tried several ideas here for general bart archs, however none of them worked well for mbart on multilingual data, but haven't experimented with bart on en data:
1. initializing ontology embeddings as average pooling of all subword embeddings.
2. initializing pointer attention mha with some layer from bart decoder

Differential Revision: D20530432

