### PR TITLE
examples/translation: Specifiy the correct bpe when loading WMT19

### DIFF
--- a/examples/translation/README.md
+++ b/examples/translation/README.md
@@ -65,6 +65,13 @@ zh2en.translate('你好 世界')
 # 'Hello World'
 ```
 
+If you are using a `transformer.wmt19` model, you will need to set the `bpe` argument to `'fastbpe'`:
+```python
+en2de = torch.hub.load('pytorch/fairseq', 'transformer.wmt19.en-de', checkpoint_file='model1.pt:model2.pt:model3.pt:model4.pt',
+                       tokenizer='moses', bpe='fastbpe')
+en2de.eval()  # disable dropout
+```
+
 ## Example usage (CLI tools)
 
 Generation with the binarized test sets can be run in batch mode as follows, e.g. for WMT 2014 English-French on a GTX-1080ti:

--- a/examples/translation/README.md
+++ b/examples/translation/README.md
@@ -33,7 +33,7 @@ import torch
 torch.hub.list('pytorch/fairseq')  # [..., 'transformer.wmt16.en-de', ... ]
 
 # Load a transformer trained on WMT'16 En-De
-en2de = torch.hub.load('pytorch/fairseq', 'transformer.wmt16.en-de', tokenizer='moses', bpe='subword_nmt')
+en2de = torch.hub.load('pytorch/fairseq', 'transformer.wmt16.en-de')
 en2de.eval()  # disable dropout
 
 # The underlying model is available under the *models* attribute
@@ -63,13 +63,6 @@ zh2en = TransformerModel.from_pretrained(
 )
 zh2en.translate('你好 世界')
 # 'Hello World'
-```
-
-If you are using a `transformer.wmt19` model, you will need to set the `bpe` argument to `'fastbpe'`:
-```python
-en2de = torch.hub.load('pytorch/fairseq', 'transformer.wmt19.en-de', checkpoint_file='model1.pt:model2.pt:model3.pt:model4.pt',
-                       tokenizer='moses', bpe='fastbpe')
-en2de.eval()  # disable dropout
 ```
 
 ## Example usage (CLI tools)


### PR DESCRIPTION
# Description

In [examples/translation](https://github.com/pytorch/fairseq/tree/master/examples/translation), the code will not run if you change the model from `transformer.wmt16` to `transformer.wmt19`, since the BPE they are using are different. I corrected that with a note at the end of the section.