### PR TITLE
Deprecate the SequenceGenerator with the Scripted vision (#1120)

### DIFF
--- a/fairseq/models/fairseq_decoder.py
+++ b/fairseq/models/fairseq_decoder.py
@@ -57,7 +57,7 @@ class FairseqDecoder(nn.Module):
 
     def get_normalized_probs(
         self,
-        net_output: Tuple[Tensor, Dict[str, List[Optional[Tensor]]]],
+        net_output: Tuple[Tensor, Optional[Dict[str, List[Optional[Tensor]]]]],
         log_probs: bool,
         sample: Optional[Dict[str, Tensor]],
     ):

--- a/fairseq/models/fairseq_model.py
+++ b/fairseq/models/fairseq_model.py
@@ -45,7 +45,7 @@ class BaseFairseqModel(nn.Module):
 
     def get_normalized_probs(
         self,
-        net_output: Tuple[Tensor, Dict[str, List[Optional[Tensor]]]],
+        net_output: Tuple[Tensor, Optional[Dict[str, List[Optional[Tensor]]]]],
         log_probs: bool,
         sample: Optional[Dict[str, Tensor]] = None,
     ):
@@ -58,7 +58,7 @@ class BaseFairseqModel(nn.Module):
     # call the helper function from scriptable Subclass.
     def get_normalized_probs_scriptable(
         self,
-        net_output: Tuple[Tensor, Dict[str, List[Optional[Tensor]]]],
+        net_output: Tuple[Tensor, Optional[Dict[str, List[Optional[Tensor]]]]],
         log_probs: bool,
         sample: Optional[Dict[str, Tensor]] = None,
     ):

--- a/fairseq/models/transformer.py
+++ b/fairseq/models/transformer.py
@@ -280,7 +280,7 @@ class TransformerModel(FairseqEncoderDecoderModel):
     @torch.jit.export
     def get_normalized_probs(
         self,
-        net_output: Tuple[Tensor, Dict[str, List[Optional[Tensor]]]],
+        net_output: Tuple[Tensor, Optional[Dict[str, List[Optional[Tensor]]]]],
         log_probs: bool,
         sample: Optional[Dict[str, Tensor]] = None,
     ):

--- a/fairseq/sequence_generator.py
+++ b/fairseq/sequence_generator.py
@@ -4,36 +4,41 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
+from typing import Dict, List, Optional
 
 import torch
-
+import torch.nn as nn
 from fairseq import search, utils
 from fairseq.data import data_utils
 from fairseq.models import FairseqIncrementalDecoder
+from fairseq.models.fairseq_encoder import EncoderOut
+from torch import Tensor
 
 
-class SequenceGenerator(object):
+class SequenceGenerator(nn.Module):
     def __init__(
         self,
+        models,
         tgt_dict,
         beam_size=1,
         max_len_a=0,
         max_len_b=200,
         min_len=1,
         normalize_scores=True,
-        len_penalty=1.,
-        unk_penalty=0.,
+        len_penalty=1.0,
+        unk_penalty=0.0,
         retain_dropout=False,
-        temperature=1.,
+        temperature=1.0,
         match_source_len=False,
         no_repeat_ngram_size=0,
         search_strategy=None,
-        eos=None
+        eos=None,
     ):
         """Generates translations of a given source sentence.
 
         Args:
-            tgt_dict (~fairseq.data.Dictionary): target dictionary
+            models (List[~fairseq.models.FairseqModel]): ensemble of models,
+                currently support fairseq.models.TransformerModel for scripting
             beam_size (int, optional): beam width (default: 1)
             max_len_a/b (int, optional): generate sequences of maximum length
                 ax + b, where x is the source length
@@ -53,6 +58,11 @@ class SequenceGenerator(object):
             match_source_len (bool, optional): outputs should match the source
                 length (default: False)
         """
+        super().__init__()
+        if isinstance(models, EnsembleModel):
+            self.model = models
+        else:
+            self.model = EnsembleModel(models)
         self.pad = tgt_dict.pad()
         self.unk = tgt_dict.unk()
         self.eos = tgt_dict.eos() if eos is None else eos
@@ -63,6 +73,7 @@ class SequenceGenerator(object):
         self.max_len_a = max_len_a
         self.max_len_b = max_len_b
         self.min_len = min_len
+
         self.normalize_scores = normalize_scores
         self.len_penalty = len_penalty
         self.unk_penalty = unk_penalty
@@ -70,16 +81,72 @@ class SequenceGenerator(object):
         self.temperature = temperature
         self.match_source_len = match_source_len
         self.no_repeat_ngram_size = no_repeat_ngram_size
-        assert temperature > 0, '--temperature must be greater than 0'
+        assert temperature > 0, "--temperature must be greater than 0"
 
         self.search = (
             search.BeamSearch(tgt_dict) if search_strategy is None else search_strategy
         )
+        if not self.retain_dropout:
+            self.model.eval()
 
+    def cuda(self):
+        self.model.cuda()
+        return self
 
     @torch.no_grad()
-    def generate(self, models, sample, **kwargs):
+    def forward(
+        self,
+        sample: Dict[str, Dict[str, Tensor]],
+        prefix_tokens: Optional[Tensor] = None,
+        bos_token: Optional[int] = None,
+    ):
         """Generate a batch of translations.
+
+        Args:
+            sample (dict): batch
+            prefix_tokens (torch.LongTensor, optional): force decoder to begin
+                with these tokens
+            bos_token (int, optional): beginning of sentence token
+                (default: self.eos)
+        """
+        self.model.reset_incremental_state()
+        return self._generate(sample, prefix_tokens, bos_token)
+
+    def generate_batched_itr(self, data_itr, beam_size=None, cuda=False, timer=None):
+        """Iterate over a batched dataset and yield individual translations.
+        Args:
+            cuda (bool, optional): use GPU for generation
+            timer (StopwatchMeter, optional): time generations
+        """
+        for sample in data_itr:
+            s = utils.move_to_cuda(sample) if cuda else sample
+            if "net_input" not in s:
+                continue
+            input = s["net_input"]
+            # model.forward normally channels prev_output_tokens into the decoder
+            # separately, but SequenceGenerator directly calls model.encoder
+            encoder_input = {
+                k: v for k, v in input.items() if k != "prev_output_tokens"
+            }
+            if timer is not None:
+                timer.start()
+            with torch.no_grad():
+                hypos = self.generate(encoder_input)
+            if timer is not None:
+                timer.stop(sum(len(h[0]["tokens"]) for h in hypos))
+            for i, id in enumerate(s["id"].data):
+                # remove padding
+                src = utils.strip_pad(input["src_tokens"].data[i, :], self.pad)
+                ref = (
+                    utils.strip_pad(s["target"].data[i, :], self.pad)
+                    if s["target"] is not None
+                    else None
+                )
+                yield id, src, ref, hypos[i]
+
+    @torch.no_grad()
+    def generate(self, models, sample: Dict[str, Dict[str, Tensor]], **kwargs):
+        """Generate translations. Match the api of other fairseq generators.
 
         Args:
             models (List[~fairseq.models.FairseqModel]): ensemble of models
@@ -89,70 +156,86 @@ class SequenceGenerator(object):
             bos_token (int, optional): beginning of sentence token
                 (default: self.eos)
         """
-        model = EnsembleModel(models)
-        return self._generate(model, sample, **kwargs)
+        self.model.reset_incremental_state()
+        return self._generate(sample, **kwargs)
 
-    @torch.no_grad()
     def _generate(
         self,
-        model,
-        sample,
-        prefix_tokens=None,
-        bos_token=None,
-        **kwargs
+        sample: Dict[str, Dict[str, Tensor]],
+        prefix_tokens: Optional[Tensor] = None,
+        bos_token: Optional[int] = None,
     ):
-        if not self.retain_dropout:
-            model.eval()
 
-        # model.forward normally channels prev_output_tokens into the decoder
-        # separately, but SequenceGenerator directly calls model.encoder
-        encoder_input = {
-            k: v for k, v in sample['net_input'].items()
-            if k != 'prev_output_tokens'
-        }
+        encoder_input: Dict[str, Tensor] = {}
+        for k, v in sample["net_input"].items():
+            if k != "prev_output_tokens":
+                encoder_input[k] = v
 
-        src_tokens = encoder_input['src_tokens']
-        src_lengths = (src_tokens.ne(self.eos) & src_tokens.ne(self.pad)).long().sum(dim=1)
-        input_size = src_tokens.size()
-        # batch dimension goes first followed by source lengths
-        bsz = input_size[0]
-        src_len = input_size[1]
+        src_tokens = encoder_input["src_tokens"]
+        # length of the source text being the character length except EndOfSentence and pad
+        src_lengths = (
+            (src_tokens.ne(self.eos) & src_tokens.ne(self.pad)).long().sum(dim=1)
+        )
+        # bsz: total number of sentences in beam
+        bsz, src_len = src_tokens.size()
         beam_size = self.beam_size
 
+        max_len: int = -1
         if self.match_source_len:
             max_len = src_lengths.max().item()
         else:
             max_len = min(
                 int(self.max_len_a * src_len + self.max_len_b),
                 # exclude the EOS marker
-                model.max_decoder_positions() - 1,
+                self.model.max_decoder_positions() - 1,
             )
-        assert self.min_len <= max_len, 'min_len cannot be larger than max_len, please adjust these!'
-
+        assert (
+            self.min_len <= max_len
+        ), "min_len cannot be larger than max_len, please adjust these!"
         # compute the encoder output for each beam
-        encoder_outs = model.forward_encoder(encoder_input)
+        encoder_outs = self.model.forward_encoder(
+            src_tokens=encoder_input["src_tokens"],
+            src_lengths=encoder_input["src_lengths"],
+        )
+
+        # placeholder of indices for bsz * beam_size to hold tokens and accumulative scores
         new_order = torch.arange(bsz).view(-1, 1).repeat(1, beam_size).view(-1)
         new_order = new_order.to(src_tokens.device).long()
-        encoder_outs = model.reorder_encoder_out(encoder_outs, new_order)
+        encoder_outs = self.model.reorder_encoder_out(encoder_outs, new_order)
+        # ensure encoder_outs is a List.
+        assert encoder_outs is not None
 
         # initialize buffers
-        scores = src_tokens.new(bsz * beam_size, max_len + 1).float().fill_(0)
-        scores_buf = scores.clone()
-        tokens = src_tokens.new(bsz * beam_size, max_len + 2).long().fill_(self.pad)
-        tokens_buf = tokens.clone()
+        scores = (
+            torch.zeros(bsz * beam_size, max_len + 1).to(src_tokens).float()
+        )  # +1 for eos; pad is never choosed for scoring
+        tokens = (
+            torch.zeros(bsz * beam_size, max_len + 2)
+            .to(src_tokens)
+            .long()
+            .fill_(self.pad)
+        )  # +2 for eos and pad
         tokens[:, 0] = self.eos if bos_token is None else bos_token
-        attn, attn_buf = None, None
+        attn: Optional[Tensor] = None
 
         # The blacklist indicates candidates that should be ignored.
         # For example, suppose we're sampling and have already finalized 2/5
         # samples. Then the blacklist would mark 2 positions as being ignored,
         # so that we only finalize the remaining 3 samples.
-        blacklist = src_tokens.new_zeros(bsz, beam_size).eq(-1)  # forward and backward-compatible False mask
+        blacklist = (
+            torch.zeros(bsz, beam_size).to(src_tokens).eq(-1)
+        )  # forward and backward-compatible False mask
 
         # list of completed sentences
-        finalized = [[] for i in range(bsz)]
-        finished = [False for i in range(bsz)]
-        num_remaining_sent = bsz
+        finalized = torch.jit.annotate(
+            List[List[Dict[str, Tensor]]],
+            [torch.jit.annotate(List[Dict[str, Tensor]], []) for i in range(bsz)],
+        )  # contains lists of dictionaries of infomation about the hypothesis being finalized at each step
+
+        finished = [
+            False for i in range(bsz)
+        ]  # a boolean array indicating if the sentence at the index is finished or not
+        num_remaining_sent = bsz  # number of sentences remaining
 
         # number of candidate hypos per step
         cand_size = 2 * beam_size  # 2 x beam size in case half are EOS
@@ -161,206 +244,71 @@ class SequenceGenerator(object):
         bbsz_offsets = (torch.arange(0, bsz) * beam_size).unsqueeze(1).type_as(tokens)
         cand_offsets = torch.arange(0, cand_size).type_as(tokens)
 
-        # helper function for allocating buffers on the fly
-        buffers = {}
-
-        def buffer(name, type_of=tokens):  # noqa
-            if name not in buffers:
-                buffers[name] = type_of.new()
-            return buffers[name]
-
-        def is_finished(sent, step, unfin_idx):
-            """
-            Check whether we've finished generation for a given sentence, by
-            comparing the worst score among finalized hypotheses to the best
-            possible score among unfinalized hypotheses.
-            """
-            assert len(finalized[sent]) <= beam_size
-            if len(finalized[sent]) == beam_size or step == max_len:
-                return True
-            return False
-
-        def finalize_hypos(step, bbsz_idx, eos_scores):
-            """
-            Finalize the given hypotheses at this step, while keeping the total
-            number of finalized hypotheses per sentence <= beam_size.
-
-            Note: the input must be in the desired finalization order, so that
-            hypotheses that appear earlier in the input are preferred to those
-            that appear later.
-
-            Args:
-                step: current time step
-                bbsz_idx: A vector of indices in the range [0, bsz*beam_size),
-                    indicating which hypotheses to finalize
-                eos_scores: A vector of the same size as bbsz_idx containing
-                    scores for each hypothesis
-            """
-            assert bbsz_idx.numel() == eos_scores.numel()
-
-            # clone relevant token and attention tensors
-            tokens_clone = tokens.index_select(0, bbsz_idx)
-            tokens_clone = tokens_clone[:, 1:step + 2]  # skip the first index, which is EOS
-            assert not tokens_clone.eq(self.eos).any()
-            tokens_clone[:, step] = self.eos
-            attn_clone = attn.index_select(0, bbsz_idx)[:, :, 1:step+2] if attn is not None else None
-
-            # compute scores per token position
-            pos_scores = scores.index_select(0, bbsz_idx)[:, :step+1]
-            pos_scores[:, step] = eos_scores
-            # convert from cumulative to per-position scores
-            pos_scores[:, 1:] = pos_scores[:, 1:] - pos_scores[:, :-1]
-
-            # normalize sentence-level scores
-            if self.normalize_scores:
-                eos_scores /= (step + 1) ** self.len_penalty
-
-            cum_unfin = []
-            prev = 0
-            for f in finished:
-                if f:
-                    prev += 1
-                else:
-                    cum_unfin.append(prev)
-
-            sents_seen = set()
-            for i, (idx, score) in enumerate(zip(bbsz_idx.tolist(), eos_scores.tolist())):
-                unfin_idx = idx // beam_size
-                sent = unfin_idx + cum_unfin[unfin_idx]
-
-                sents_seen.add((sent, unfin_idx))
-
-                if self.match_source_len and step > src_lengths[unfin_idx]:
-                    score = -math.inf
-
-                def get_hypo():
-
-                    if attn_clone is not None:
-                        # remove padding tokens from attn scores
-                        hypo_attn = attn_clone[i]
-                    else:
-                        hypo_attn = None
-
-                    return {
-                        'tokens': tokens_clone[i],
-                        'score': score,
-                        'attention': hypo_attn,  # src_len x tgt_len
-                        'alignment': None,
-                        'positional_scores': pos_scores[i],
-                    }
-
-                if len(finalized[sent]) < beam_size:
-                    finalized[sent].append(get_hypo())
-
-            newly_finished = []
-            for sent, unfin_idx in sents_seen:
-                # check termination conditions for this sentence
-                if not finished[sent] and is_finished(sent, step, unfin_idx):
-                    finished[sent] = True
-                    newly_finished.append(unfin_idx)
-            return newly_finished
-
-        reorder_state = None
-        batch_idxs = None
+        reorder_state: Optional[Tensor] = None
+        batch_idxs: Optional[Tensor] = None
         for step in range(max_len + 1):  # one extra step for EOS marker
             # reorder decoder internal states based on the prev choice of beams
+            # print(f'step: {step}')
             if reorder_state is not None:
                 if batch_idxs is not None:
                     # update beam indices to take into account removed sentences
-                    corr = batch_idxs - torch.arange(batch_idxs.numel()).type_as(batch_idxs)
-                    reorder_state.view(-1, beam_size).add_(corr.unsqueeze(-1) * beam_size)
-                model.reorder_incremental_state(reorder_state)
-                encoder_outs = model.reorder_encoder_out(encoder_outs, reorder_state)
+                    corr = batch_idxs - torch.arange(batch_idxs.numel()).type_as(
+                        batch_idxs
+                    )
+                    reorder_state.view(-1, beam_size).add_(
+                        corr.unsqueeze(-1) * beam_size
+                    )
+                self.model.reorder_incremental_state(reorder_state)
+                encoder_outs = self.model.reorder_encoder_out(
+                    encoder_outs, reorder_state
+                )
 
-            lprobs, avg_attn_scores = model.forward_decoder(
-                tokens[:, :step + 1], encoder_outs, temperature=self.temperature,
+            lprobs, avg_attn_scores = self.model.forward_decoder(
+                tokens[:, : step + 1], encoder_outs, self.temperature
             )
-            lprobs[lprobs != lprobs] = -math.inf
+            lprobs[lprobs != lprobs] = torch.tensor(-math.inf).to(lprobs)
 
             lprobs[:, self.pad] = -math.inf  # never select pad
             lprobs[:, self.unk] -= self.unk_penalty  # apply unk penalty
 
             # handle max length constraint
             if step >= max_len:
-                lprobs[:, :self.eos] = -math.inf
-                lprobs[:, self.eos + 1:] = -math.inf
+                lprobs[:, : self.eos] = -math.inf
+                lprobs[:, self.eos + 1 :] = -math.inf
 
             # handle prefix tokens (possibly with different lengths)
-            if prefix_tokens is not None and step < prefix_tokens.size(1) and step < max_len:
-                prefix_toks = prefix_tokens[:, step].unsqueeze(-1).repeat(1, beam_size).view(-1)
-                prefix_lprobs = lprobs.gather(-1, prefix_toks.unsqueeze(-1))
-                prefix_mask = prefix_toks.ne(self.pad)
-                lprobs[prefix_mask] = -math.inf
-                lprobs[prefix_mask] = lprobs[prefix_mask].scatter_(
-                    -1, prefix_toks[prefix_mask].unsqueeze(-1), prefix_lprobs[prefix_mask]
+            if (
+                prefix_tokens is not None
+                and step < prefix_tokens.size(1)
+                and step < max_len
+            ):
+                lprobs, tokens, scores = self._prefix_tokens(
+                    step, lprobs, scores, tokens, prefix_tokens, beam_size
                 )
-                # if prefix includes eos, then we should make sure tokens and
-                # scores are the same across all beams
-                eos_mask = prefix_toks.eq(self.eos)
-                if eos_mask.any():
-                    # validate that the first beam matches the prefix
-                    first_beam = tokens[eos_mask].view(-1, beam_size, tokens.size(-1))[:, 0, 1:step + 1]
-                    eos_mask_batch_dim = eos_mask.view(-1, beam_size)[:, 0]
-                    target_prefix = prefix_tokens[eos_mask_batch_dim][:, :step]
-                    assert (first_beam == target_prefix).all()
-
-                    def replicate_first_beam(tensor, mask):
-                        tensor = tensor.view(-1, beam_size, tensor.size(-1))
-                        tensor[mask] = tensor[mask][:, :1, :]
-                        return tensor.view(-1, tensor.size(-1))
-
-                    # copy tokens, scores and lprobs from the first beam to all beams
-                    tokens = replicate_first_beam(tokens, eos_mask_batch_dim)
-                    scores = replicate_first_beam(scores, eos_mask_batch_dim)
-                    lprobs = replicate_first_beam(lprobs, eos_mask_batch_dim)
             elif step < self.min_len:
                 # minimum length constraint (does not apply if using prefix_tokens)
                 lprobs[:, self.eos] = -math.inf
 
-            if self.no_repeat_ngram_size > 0:
-                # for each beam and batch sentence, generate a list of previous ngrams
-                gen_ngrams = [{} for bbsz_idx in range(bsz * beam_size)]
-                cpu_tokens = tokens.cpu()
-                for bbsz_idx in range(bsz * beam_size):
-                    gen_tokens = cpu_tokens[bbsz_idx].tolist()
-                    for ngram in zip(*[gen_tokens[i:] for i in range(self.no_repeat_ngram_size)]):
-                        if ngram[-1] != self.pad:
-                            gen_ngrams[bbsz_idx][tuple(ngram[:-1])] = \
-                                    gen_ngrams[bbsz_idx].get(tuple(ngram[:-1]), []) + [ngram[-1]]
-
-            # Record attention scores
-            if type(avg_attn_scores) is list:
-                avg_attn_scores = avg_attn_scores[0]
+            # Record attention scores, only support avg_attn_scores is a Tensor
             if avg_attn_scores is not None:
                 if attn is None:
-                    attn = scores.new(bsz * beam_size, avg_attn_scores.size(1), max_len + 2)
-                    attn_buf = attn.clone()
+                    attn = torch.empty(
+                        bsz * beam_size, avg_attn_scores.size(1), max_len + 2
+                    ).to(scores)
                 attn[:, :, step + 1].copy_(avg_attn_scores)
 
             scores = scores.type_as(lprobs)
-            scores_buf = scores_buf.type_as(lprobs)
-            eos_bbsz_idx = buffer('eos_bbsz_idx')
-            eos_scores = buffer('eos_scores', type_of=scores)
+            eos_bbsz_idx = torch.empty(0).to(
+                tokens
+            )  # indices of hypothesis ending with eos (finished sentences)
+            eos_scores = torch.empty(0).to(
+                scores
+            )  # scores of hypothesis ending with eos (finished sentences)
 
             self.search.set_src_lengths(src_lengths)
 
             if self.no_repeat_ngram_size > 0:
-                def calculate_banned_tokens(bbsz_idx):
-                    # before decoding the next token, prevent decoding of ngrams that have already appeared
-                    ngram_index = tuple(cpu_tokens[bbsz_idx, step + 2 - self.no_repeat_ngram_size:step + 1].tolist())
-                    banned_tokens_per_sample = gen_ngrams[bbsz_idx].get(ngram_index, [])
-                    banned_tokens_per_sample = [(bbsz_idx, t) for t in banned_tokens_per_sample]
-                    return banned_tokens_per_sample
-
-                banned_tokens = []
-                if step + 2 - self.no_repeat_ngram_size >= 0:
-                    # no banned tokens if we haven't generated no_repeat_ngram_size tokens yet
-                    for bbsz_idx in range(bsz * beam_size):
-                        banned_tokens.extend(calculate_banned_tokens(bbsz_idx))
-
-                if banned_tokens:
-                    banned_tokens = torch.LongTensor(banned_tokens)
-                    lprobs.index_put_(tuple(banned_tokens.t()), lprobs.new_tensor([-math.inf] * len(banned_tokens)))
+                lprobs = self._no_repeat_ngram(tokens, lprobs, bsz, beam_size, step)
 
             cand_scores, cand_indices, cand_beams = self.search.step(
                 step,
@@ -373,26 +321,33 @@ class SequenceGenerator(object):
             # and dimensions: [bsz, cand_size]
             cand_bbsz_idx = cand_beams.add(bbsz_offsets)
 
-            # finalize hypotheses that end in eos, except for blacklisted ones
-            # or candidates with a score of -inf
+            # finalize hypotheses that end in eos
             eos_mask = cand_indices.eq(self.eos) & cand_scores.ne(-math.inf)
-            eos_mask[:, :beam_size][blacklist] = 0
+            eos_mask[:, :beam_size][blacklist] = torch.tensor(0).to(eos_mask)
 
             # only consider eos when it's among the top beam_size indices
-            torch.masked_select(
-                cand_bbsz_idx[:, :beam_size],
-                mask=eos_mask[:, :beam_size],
-                out=eos_bbsz_idx,
+            eos_bbsz_idx = torch.masked_select(
+                cand_bbsz_idx[:, :beam_size], mask=eos_mask[:, :beam_size]
             )
 
-            finalized_sents = set()
+            finalized_sents: List[int] = []
             if eos_bbsz_idx.numel() > 0:
-                torch.masked_select(
-                    cand_scores[:, :beam_size],
-                    mask=eos_mask[:, :beam_size],
-                    out=eos_scores,
+                eos_scores = torch.masked_select(
+                    cand_scores[:, :beam_size], mask=eos_mask[:, :beam_size]
                 )
-                finalized_sents = finalize_hypos(step, eos_bbsz_idx, eos_scores)
+                finalized_sents = self.finalize_hypos(
+                    step,
+                    eos_bbsz_idx,
+                    eos_scores,
+                    tokens,
+                    scores,
+                    finalized,
+                    finished,
+                    beam_size,
+                    attn,
+                    src_lengths,
+                    max_len,
+                )
                 num_remaining_sent -= len(finalized_sents)
 
             assert num_remaining_sent >= 0
@@ -404,8 +359,10 @@ class SequenceGenerator(object):
                 new_bsz = bsz - len(finalized_sents)
 
                 # construct batch_idxs which holds indices of batches to keep for the next pass
-                batch_mask = cand_indices.new_ones(bsz)
-                batch_mask[cand_indices.new(finalized_sents)] = 0
+                batch_mask = torch.ones(bsz).to(cand_indices)
+                batch_mask[
+                    torch.tensor(finalized_sents).to(cand_indices)
+                ] = torch.tensor(0).to(batch_mask)
                 batch_idxs = batch_mask.nonzero().squeeze(-1)
 
                 eos_mask = eos_mask[batch_idxs]
@@ -414,198 +371,430 @@ class SequenceGenerator(object):
                 cand_bbsz_idx = cand_beams.add(bbsz_offsets)
                 cand_scores = cand_scores[batch_idxs]
                 cand_indices = cand_indices[batch_idxs]
+
                 if prefix_tokens is not None:
                     prefix_tokens = prefix_tokens[batch_idxs]
                 src_lengths = src_lengths[batch_idxs]
                 blacklist = blacklist[batch_idxs]
 
                 scores = scores.view(bsz, -1)[batch_idxs].view(new_bsz * beam_size, -1)
-                scores_buf.resize_as_(scores)
                 tokens = tokens.view(bsz, -1)[batch_idxs].view(new_bsz * beam_size, -1)
-                tokens_buf.resize_as_(tokens)
                 if attn is not None:
-                    attn = attn.view(bsz, -1)[batch_idxs].view(new_bsz * beam_size, attn.size(1), -1)
-                    attn_buf.resize_as_(attn)
+                    attn = attn.view(bsz, -1)[batch_idxs].view(
+                        new_bsz * beam_size, attn.size(1), -1
+                    )
                 bsz = new_bsz
             else:
                 batch_idxs = None
+            # set active_mask so that values > cand_size indicate eos hypos
+            # and values < cand_size indicate candidate active hypos.
+            # After, the min values per row are the top candidate active hypos
 
-            # Set active_mask so that values > cand_size indicate eos or
-            # blacklisted hypos and values < cand_size indicate candidate
-            # active hypos. After this, the min values per row are the top
-            # candidate active hypos.
-            active_mask = buffer('active_mask')
-            eos_mask[:, :beam_size] |= blacklist
-            torch.add(
+            # Rewrite the operator since the element wise or is not supported in torchscript.
+
+            eos_mask[:, :beam_size] = ~((~blacklist) & (~eos_mask[:, :beam_size]))
+            active_mask = torch.add(
                 eos_mask.type_as(cand_offsets) * cand_size,
-                cand_offsets[:eos_mask.size(1)],
-                out=active_mask,
+                cand_offsets[: eos_mask.size(1)],
             )
 
             # get the top beam_size active hypotheses, which are just the hypos
             # with the smallest values in active_mask
-            active_hypos, new_blacklist = buffer('active_hypos'), buffer('new_blacklist')
-            torch.topk(
-                active_mask, k=beam_size, dim=1, largest=False,
-                out=(new_blacklist, active_hypos)
+            new_blacklist, active_hypos = torch.topk(
+                active_mask, k=beam_size, dim=1, largest=False
             )
 
             # update blacklist to ignore any finalized hypos
             blacklist = new_blacklist.ge(cand_size)[:, :beam_size]
             assert (~blacklist).any(dim=1).all()
 
-            active_bbsz_idx = buffer('active_bbsz_idx')
-            torch.gather(
-                cand_bbsz_idx, dim=1, index=active_hypos,
-                out=active_bbsz_idx,
-            )
-            active_scores = torch.gather(
-                cand_scores, dim=1, index=active_hypos,
-                out=scores[:, step].view(bsz, beam_size),
-            )
+            active_bbsz_idx = torch.gather(cand_bbsz_idx, dim=1, index=active_hypos)
+            active_scores = torch.gather(cand_scores, dim=1, index=active_hypos)
 
             active_bbsz_idx = active_bbsz_idx.view(-1)
             active_scores = active_scores.view(-1)
 
             # copy tokens and scores for active hypotheses
-            torch.index_select(
-                tokens[:, :step + 1], dim=0, index=active_bbsz_idx,
-                out=tokens_buf[:, :step + 1],
+            tokens[:, : step + 1] = torch.index_select(
+                tokens[:, : step + 1], dim=0, index=active_bbsz_idx
             )
-            torch.gather(
-                cand_indices, dim=1, index=active_hypos,
-                out=tokens_buf.view(bsz, beam_size, -1)[:, :, step + 1],
+            tokens.view(bsz, beam_size, -1)[:, :, step + 1] = torch.gather(
+                cand_indices, dim=1, index=active_hypos
             )
             if step > 0:
-                torch.index_select(
-                    scores[:, :step], dim=0, index=active_bbsz_idx,
-                    out=scores_buf[:, :step],
+                scores[:, :step] = torch.index_select(
+                    scores[:, :step], dim=0, index=active_bbsz_idx
                 )
-            torch.gather(
-                cand_scores, dim=1, index=active_hypos,
-                out=scores_buf.view(bsz, beam_size, -1)[:, :, step],
+            scores.view(bsz, beam_size, -1)[:, :, step] = torch.gather(
+                cand_scores, dim=1, index=active_hypos
             )
 
             # copy attention for active hypotheses
             if attn is not None:
-                torch.index_select(
-                    attn[:, :, :step + 2], dim=0, index=active_bbsz_idx,
-                    out=attn_buf[:, :, :step + 2],
+                attn[:, :, : step + 2] = torch.index_select(
+                    attn[:, :, : step + 2], dim=0, index=active_bbsz_idx
                 )
-
-            # swap buffers
-            tokens, tokens_buf = tokens_buf, tokens
-            scores, scores_buf = scores_buf, scores
-            if attn is not None:
-                attn, attn_buf = attn_buf, attn
 
             # reorder incremental state in decoder
             reorder_state = active_bbsz_idx
 
         # sort by score descending
         for sent in range(len(finalized)):
-            finalized[sent] = sorted(finalized[sent], key=lambda r: r['score'], reverse=True)
+            # make into beam container
+            BCList = [
+                BeamContainer(elem["score"].item(), elem) for elem in finalized[sent]
+            ]
+            BCList.sort()
+            BCList.reverse()
+            finalized[sent] = torch.jit.annotate(
+                List[Dict[str, Tensor]], [x.elem for x in BCList]
+            )
+
         return finalized
 
+    def _prefix_tokens(
+        self, step: int, lprobs, scores, tokens, prefix_tokens, beam_size: int
+    ):
+        """Handle prefix tokens"""
+        prefix_toks = prefix_tokens[:, step].unsqueeze(-1).repeat(1, beam_size).view(-1)
+        prefix_lprobs = lprobs.gather(-1, prefix_toks.unsqueeze(-1))
+        prefix_mask = prefix_toks.ne(self.pad)
+        lprobs[prefix_mask] = torch.tensor(-math.inf).to(lprobs)
+        lprobs[prefix_mask] = lprobs[prefix_mask].scatter_(
+            -1, prefix_toks[prefix_mask].unsqueeze(-1), prefix_lprobs[prefix_mask]
+        )
+        # if prefix includes eos, then we should make sure tokens and
+        # scores are the same across all beams
+        eos_mask = prefix_toks.eq(self.eos)
+        if eos_mask.any():
+            # validate that the first beam matches the prefix
+            first_beam = tokens[eos_mask].view(-1, beam_size, tokens.size(-1))[
+                :, 0, 1 : step + 1
+            ]
+            eos_mask_batch_dim = eos_mask.view(-1, beam_size)[:, 0]
+            target_prefix = prefix_tokens[eos_mask_batch_dim][:, :step]
+            assert (first_beam == target_prefix).all()
 
-class EnsembleModel(torch.nn.Module):
+            # copy tokens, scores and lprobs from the first beam to all beams
+            tokens = self.replicate_first_beam(tokens, eos_mask_batch_dim, beam_size)
+            scores = self.replicate_first_beam(scores, eos_mask_batch_dim, beam_size)
+            lprobs = self.replicate_first_beam(lprobs, eos_mask_batch_dim, beam_size)
+        return lprobs, tokens, scores
+
+    def replicate_first_beam(self, tensor, mask, beam_size: int):
+        tensor = tensor.view(-1, beam_size, tensor.size(-1))
+        tensor[mask] = tensor[mask][:, :1, :]
+        return tensor.view(-1, tensor.size(-1))
+
+    def finalize_hypos(
+        self,
+        step: int,
+        bbsz_idx,
+        eos_scores,
+        tokens,
+        scores,
+        finalized: List[List[Dict[str, Tensor]]],
+        finished: List[bool],
+        beam_size: int,
+        attn: Optional[Tensor],
+        src_lengths,
+        max_len: int,
+    ):
+        """Finalize hypothesis, store finalized information in `finalized`, and change `finished` accordingly.
+        Returns number of sentences being finalized.
+        Args:
+            bbsz_idx (Tensor):
+        """
+        assert bbsz_idx.numel() == eos_scores.numel()
+
+        # clone relevant token and attention tensors
+        tokens_clone = tokens.index_select(0, bbsz_idx)[
+            :, 1 : step + 2
+        ]  # skip the first index, which is EOS
+
+        tokens_clone[:, step] = self.eos
+        attn_clone = (
+            attn.index_select(0, bbsz_idx)[:, :, 1 : step + 2]
+            if attn is not None
+            else None
+        )
+
+        # compute scores per token position
+        pos_scores = scores.index_select(0, bbsz_idx)[:, : step + 1]
+        pos_scores[:, step] = eos_scores
+        # convert from cumulative to per-position scores
+        pos_scores[:, 1:] = pos_scores[:, 1:] - pos_scores[:, :-1]
+
+        # normalize sentence-level scores
+        if self.normalize_scores:
+            eos_scores /= (step + 1) ** self.len_penalty
+
+        cum_unfin: List[int] = []
+        prev = 0
+        for f in finished:
+            if f:
+                prev += 1
+            else:
+                cum_unfin.append(prev)
+
+        # set() is not supported in script export
+        sents_seen: Dict[str, Optional[Tensor]] = {}
+        for i in range(bbsz_idx.size()[0]):
+            idx = bbsz_idx[i]
+            score = eos_scores[i]
+            unfin_idx = idx // beam_size
+            sent = unfin_idx + cum_unfin[unfin_idx]
+            # Cannot create dict for key type '(int, int)' in torchscript.
+            # The workaround is to cast int to string
+            seen = str(sent.item()) + "_" + str(unfin_idx.item())
+            if seen not in sents_seen:
+                sents_seen[seen] = None
+
+            if self.match_source_len and step > src_lengths[unfin_idx]:
+                score = torch.tensor(-math.inf).to(score)
+
+            if len(finalized[sent]) < beam_size:
+                if attn_clone is not None:
+                    # remove padding tokens from attn scores
+                    hypo_attn = attn_clone[i]
+                else:
+                    hypo_attn = torch.empty(0)
+                finalized[sent].append(
+                    {
+                        "tokens": tokens_clone[i],
+                        "score": score,
+                        "attention": hypo_attn,  # src_len x tgt_len
+                        "alignment": torch.empty(0),
+                        "positional_scores": pos_scores[i],
+                    }
+                )
+
+        newly_finished: List[int] = []
+        for seen in sents_seen.keys():
+            # check termination conditions for this sentence
+            sent: int = int(float(seen.split("_")[0]))
+            unfin_idx: int = int(float(seen.split("_")[1]))
+            if not finished[sent] and self.is_finished(
+                step, unfin_idx, max_len, len(finalized[sent]), beam_size
+            ):
+                finished[sent] = True
+                newly_finished.append(unfin_idx)
+        return newly_finished
+
+    def is_finished(
+        self,
+        step: int,
+        unfin_idx: int,
+        max_len: int,
+        finalized_sent_len: int,
+        beam_size: int,
+    ):
+        """
+        Check whether we've finished generation for a given sentence, by
+        comparing the worst score among finalized hypotheses to the best
+        possible score among unfinalized hypotheses.
+        """
+        assert finalized_sent_len <= beam_size
+        if finalized_sent_len == beam_size or step == max_len:
+            return True
+        return False
+
+    @torch.jit.unused
+    def _no_repeat_ngram(self, tokens, lprobs, bsz: int, beam_size: int, step: int):
+        # for each beam and batch sentence, generate a list of previous ngrams
+        gen_ngrams = [{} for bbsz_idx in range(bsz * beam_size)]
+        cpu_tokens = tokens.cpu()
+        for bbsz_idx in range(bsz * beam_size):
+            gen_tokens = cpu_tokens[bbsz_idx].tolist()
+            for ngram in zip(
+                *[gen_tokens[i:] for i in range(self.no_repeat_ngram_size)]
+            ):
+                if ngram[-1] != self.pad:
+                    gen_ngrams[bbsz_idx][tuple(ngram[:-1])] = gen_ngrams[bbsz_idx].get(
+                        tuple(ngram[:-1]), []
+                    ) + [ngram[-1]]
+
+        def calculate_banned_tokens(bbsz_idx):
+            # before decoding the next token, prevent decoding of ngrams that have already appeared
+            ngram_index = tuple(
+                cpu_tokens[
+                    bbsz_idx, step + 2 - self.no_repeat_ngram_size : step + 1
+                ].tolist()
+            )
+            banned_tokens_per_sample = gen_ngrams[bbsz_idx].get(ngram_index, [])
+            banned_tokens_per_sample = [(bbsz_idx, t) for t in banned_tokens_per_sample]
+            return banned_tokens_per_sample
+
+        banned_tokens = []
+        if step + 2 - self.no_repeat_ngram_size >= 0:
+            # no banned tokens if we haven't generated no_repeat_ngram_size tokens yet
+            for bbsz_idx in range(bsz * beam_size):
+                banned_tokens.extend(calculate_banned_tokens(bbsz_idx))
+
+        if banned_tokens:
+            banned_tokens = torch.LongTensor(banned_tokens)
+            lprobs.index_put_(
+                tuple(banned_tokens.t()),
+                lprobs.new_tensor([-math.inf] * len(banned_tokens)),
+            )
+        return lprobs
+
+
+class EnsembleModel(nn.Module):
     """A wrapper around an ensemble of models."""
+
+    incremental_states: List[Dict[str, Dict[str, Optional[Tensor]]]]
 
     def __init__(self, models):
         super().__init__()
-        self.models = torch.nn.ModuleList(models)
-        self.incremental_states = None
-        if all(hasattr(m, 'decoder') and isinstance(m.decoder, FairseqIncrementalDecoder) for m in models):
-            self.incremental_states = {m: {} for m in models}
+        self.models_size = len(models)
+        # method '__len__' is not supported in ModuleList for torch script
+        self.single_model = models[0]
+        self.models = nn.ModuleList(models)
+
+        self.incremental_states = torch.jit.annotate(
+            List[Dict[str, Dict[str, Optional[Tensor]]]],
+            [
+                torch.jit.annotate(Dict[str, Dict[str, Optional[Tensor]]], {})
+                for i in range(self.models_size)
+            ],
+        )
+        self.has_incremental: bool = False
+        if all(
+            hasattr(m, "decoder") and isinstance(m.decoder, FairseqIncrementalDecoder)
+            for m in models
+        ):
+            self.has_incremental = True
+
+    def forward(self):
+        pass
+
+    def reset_incremental_state(self):
+        if self.has_incremental_states():
+            self.incremental_states = torch.jit.annotate(
+                List[Dict[str, Dict[str, Optional[Tensor]]]],
+                [
+                    torch.jit.annotate(Dict[str, Dict[str, Optional[Tensor]]], {})
+                    for i in range(self.models_size)
+                ],
+            )
+        return
 
     def has_encoder(self):
-        return hasattr(self.models[0], 'encoder')
+        return hasattr(self.single_model, "encoder")
+
+    def has_incremental_states(self):
+        return self.has_incremental
 
     def max_decoder_positions(self):
-        return min(m.max_decoder_positions() for m in self.models)
+        return min([m.max_decoder_positions() for m in self.models])
 
-    @torch.no_grad()
-    def forward_encoder(self, encoder_input):
+    @torch.jit.export
+    def forward_encoder(self, src_tokens, src_lengths):
         if not self.has_encoder():
             return None
-        return [model.encoder(**encoder_input) for model in self.models]
+        return [
+            model.encoder(src_tokens=src_tokens, src_lengths=src_lengths)
+            for model in self.models
+        ]
 
-    @torch.no_grad()
-    def forward_decoder(self, tokens, encoder_outs, temperature=1.):
-        if len(self.models) == 1:
-            return self._decode_one(
-                tokens,
-                self.models[0],
-                encoder_outs[0] if self.has_encoder() else None,
-                self.incremental_states,
-                log_probs=True,
-                temperature=temperature,
-            )
-
+    @torch.jit.export
+    def forward_decoder(
+        self, tokens, encoder_outs: List[EncoderOut], temperature: float = 1.0
+    ):
         log_probs = []
-        avg_attn = None
-        for model, encoder_out in zip(self.models, encoder_outs):
-            probs, attn = self._decode_one(
-                tokens,
-                model,
-                encoder_out,
-                self.incremental_states,
-                log_probs=True,
-                temperature=temperature,
+        avg_attn: Optional[Tensor] = None
+        encoder_out: Optional[EncoderOut] = None
+        for i, model in enumerate(self.models):
+            if self.has_encoder():
+                encoder_out = encoder_outs[i]
+            # decode each model
+            if self.has_incremental_states():
+                decoder_out = model.decoder.forward(
+                    tokens,
+                    encoder_out=encoder_out,
+                    incremental_state=self.incremental_states[i],
+                )
+            else:
+                decoder_out = model.decoder.forward(tokens, encoder_out=encoder_out)
+
+            attn: Optional[Tensor] = None
+            # __len__ is not supported in Tuple in Script.
+            decoder_len = 0
+            for _ in decoder_out:
+                decoder_len += 1
+
+            if decoder_len > 1 and decoder_out[1] is not None:
+                if isinstance(decoder_out[1], Tensor):
+                    attn = decoder_out[1]
+                else:
+                    attn_holder = decoder_out[1]["attn"]
+                    if isinstance(attn_holder, Tensor):
+                        attn = attn_holder
+                    elif attn_holder is not None:
+                        attn = attn_holder[0]
+                if attn is not None:
+                    attn = attn[:, -1, :]
+
+            decoder_out_tuple = (
+                decoder_out[0][:, -1:, :].div_(temperature),
+                None if decoder_len <= 1 else decoder_out[1],
             )
+
+            probs = model.get_normalized_probs(
+                decoder_out_tuple, log_probs=True, sample=None
+            )
+            probs = probs[:, -1, :]
+            if self.models_size == 1:
+                return probs, attn
+
             log_probs.append(probs)
             if attn is not None:
                 if avg_attn is None:
                     avg_attn = attn
                 else:
                     avg_attn.add_(attn)
-        avg_probs = torch.logsumexp(torch.stack(log_probs, dim=0), dim=0) - math.log(len(self.models))
+        avg_probs = torch.logsumexp(torch.stack(log_probs, dim=0), dim=0) - math.log(
+            self.models_size
+        )
         if avg_attn is not None:
-            avg_attn.div_(len(self.models))
+            avg_attn.div_(self.models_size)
         return avg_probs, avg_attn
 
-    def _decode_one(
-        self, tokens, model, encoder_out, incremental_states, log_probs,
-        temperature=1.,
-    ):
-        if self.incremental_states is not None:
-            decoder_out = list(model.forward_decoder(
-                tokens, encoder_out=encoder_out, incremental_state=self.incremental_states[model],
-            ))
-        else:
-            decoder_out = list(model.forward_decoder(tokens, encoder_out=encoder_out))
-        decoder_out[0] = decoder_out[0][:, -1:, :]
-        if temperature != 1.:
-            decoder_out[0].div_(temperature)
-        attn = decoder_out[1] if len(decoder_out) > 1 else None
-        if type(attn) is dict:
-            attn = attn.get('attn', None)
-        if type(attn) is list:
-            attn = attn[0]
-        if attn is not None:
-            attn = attn[:, -1, :]
-        probs = model.get_normalized_probs(decoder_out, log_probs=log_probs)
-        probs = probs[:, -1, :]
-        return probs, attn
+    @torch.jit.export
+    def reorder_encoder_out(self, encoder_outs: Optional[List[EncoderOut]], new_order):
+        """
+        Reorder encoder output according to *new_order*.
 
-    def reorder_encoder_out(self, encoder_outs, new_order):
+        Args:
+            encoder_out: output from the ``forward()`` method
+            new_order (LongTensor): desired order
+
+        Returns:
+            *encoder_out* rearranged according to *new_order*
+        """
+        new_outs: List[EncoderOut] = []
         if not self.has_encoder():
-            return
-        return [
-            model.encoder.reorder_encoder_out(encoder_out, new_order)
-            for model, encoder_out in zip(self.models, encoder_outs)
-        ]
+            return new_outs
+        for i, model in enumerate(self.models):
+            assert encoder_outs is not None
+            new_outs.append(
+                model.encoder.reorder_encoder_out(encoder_outs[i], new_order)
+            )
+        return new_outs
 
+    @torch.jit.export
     def reorder_incremental_state(self, new_order):
-        if self.incremental_states is None:
+        if not self.has_incremental_states():
             return
-        for model in self.models:
-            model.decoder.reorder_incremental_state(self.incremental_states[model], new_order)
+        for i, model in enumerate(self.models):
+            model.decoder.reorder_incremental_state(
+                self.incremental_states[i], new_order
+            )
 
 
 class SequenceGeneratorWithAlignment(SequenceGenerator):
-
-    def __init__(self, tgt_dict, left_pad_target=False, **kwargs):
+    def __init__(self, models, tgt_dict, left_pad_target=False, **kwargs):
         """Generates translations of a given source sentence.
 
         Produces alignments following "Jointly Learning to Align and
@@ -616,46 +805,65 @@ class SequenceGeneratorWithAlignment(SequenceGenerator):
                 hypothesis should be left padded or not when they are
                 teacher forced for generating alignments.
         """
-        super().__init__(tgt_dict, **kwargs)
+        super().__init__(EnsembleModelWithAlignment(models), tgt_dict, **kwargs)
         self.left_pad_target = left_pad_target
 
     @torch.no_grad()
     def generate(self, models, sample, **kwargs):
-        model = EnsembleModelWithAlignment(models)
-        finalized = super()._generate(model, sample, **kwargs)
+        self.model.reset_incremental_state()
+        finalized = super()._generate(sample, **kwargs)
 
-        src_tokens = sample['net_input']['src_tokens']
+        src_tokens = sample["net_input"]["src_tokens"]
         bsz = src_tokens.shape[0]
         beam_size = self.beam_size
-        src_tokens, src_lengths, prev_output_tokens, tgt_tokens = \
-            self._prepare_batch_for_alignment(sample, finalized)
-        if any(getattr(m, 'full_context_alignment', False) for m in model.models):
-            attn = model.forward_align(src_tokens, src_lengths, prev_output_tokens)
+        src_tokens, src_lengths, prev_output_tokens, tgt_tokens = self._prepare_batch_for_alignment(
+            sample, finalized
+        )
+        if any(getattr(m, "full_context_alignment", False) for m in self.model.models):
+            attn = self.model.forward_align(src_tokens, src_lengths, prev_output_tokens)
         else:
             attn = [
-                finalized[i // beam_size][i % beam_size]['attention'].transpose(1, 0)
+                finalized[i // beam_size][i % beam_size]["attention"].transpose(1, 0)
                 for i in range(bsz * beam_size)
             ]
 
         # Process the attn matrix to extract hard alignments.
         for i in range(bsz * beam_size):
-            alignment = utils.extract_hard_alignment(attn[i], src_tokens[i], tgt_tokens[i], self.pad, self.eos)
-            finalized[i // beam_size][i % beam_size]['alignment'] = alignment
+            alignment = utils.extract_hard_alignment(
+                attn[i], src_tokens[i], tgt_tokens[i], self.pad, self.eos
+            )
+            finalized[i // beam_size][i % beam_size]["alignment"] = alignment
         return finalized
 
     def _prepare_batch_for_alignment(self, sample, hypothesis):
-        src_tokens = sample['net_input']['src_tokens']
+        src_tokens = sample["net_input"]["src_tokens"]
         bsz = src_tokens.shape[0]
-        src_tokens = src_tokens[:, None, :].expand(-1, self.beam_size, -1).contiguous().view(bsz * self.beam_size, -1)
-        src_lengths = sample['net_input']['src_lengths']
-        src_lengths = src_lengths[:, None].expand(-1, self.beam_size).contiguous().view(bsz * self.beam_size)
+        src_tokens = (
+            src_tokens[:, None, :]
+            .expand(-1, self.beam_size, -1)
+            .contiguous()
+            .view(bsz * self.beam_size, -1)
+        )
+        src_lengths = sample["net_input"]["src_lengths"]
+        src_lengths = (
+            src_lengths[:, None]
+            .expand(-1, self.beam_size)
+            .contiguous()
+            .view(bsz * self.beam_size)
+        )
         prev_output_tokens = data_utils.collate_tokens(
-            [beam['tokens'] for example in hypothesis for beam in example],
-            self.pad, self.eos, self.left_pad_target, move_eos_to_beginning=True,
+            [beam["tokens"] for example in hypothesis for beam in example],
+            self.pad,
+            self.eos,
+            self.left_pad_target,
+            move_eos_to_beginning=True,
         )
         tgt_tokens = data_utils.collate_tokens(
-            [beam['tokens'] for example in hypothesis for beam in example],
-            self.pad, self.eos, self.left_pad_target, move_eos_to_beginning=False,
+            [beam["tokens"] for example in hypothesis for beam in example],
+            self.pad,
+            self.eos,
+            self.left_pad_target,
+            move_eos_to_beginning=False,
         )
         return src_tokens, src_lengths, prev_output_tokens, tgt_tokens
 
@@ -670,7 +878,7 @@ class EnsembleModelWithAlignment(EnsembleModel):
         avg_attn = None
         for model in self.models:
             decoder_out = model(src_tokens, src_lengths, prev_output_tokens)
-            attn = decoder_out[1]['attn']
+            attn = decoder_out[1]["attn"]
             if avg_attn is None:
                 avg_attn = attn
             else:
@@ -679,28 +887,16 @@ class EnsembleModelWithAlignment(EnsembleModel):
             avg_attn.div_(len(self.models))
         return avg_attn
 
-    def _decode_one(
-        self, tokens, model, encoder_out, incremental_states, log_probs,
-        temperature=1.,
-    ):
-        if self.incremental_states is not None:
-            decoder_out = list(model.forward_decoder(
-                tokens,
-                encoder_out=encoder_out,
-                incremental_state=self.incremental_states[model],
-            ))
-        else:
-            decoder_out = list(model.forward_decoder(tokens, encoder_out=encoder_out))
-        decoder_out[0] = decoder_out[0][:, -1:, :]
-        if temperature != 1.:
-            decoder_out[0].div_(temperature)
-        attn = decoder_out[1] if len(decoder_out) > 1 else None
-        if type(attn) is dict:
-            attn = attn.get('attn', None)
-        if type(attn) is list:
-            attn = attn[0]
-        if attn is not None:
-            attn = attn[:, -1, :]
-        probs = model.get_normalized_probs(decoder_out, log_probs=log_probs)
-        probs = probs[:, -1, :]
-        return probs, attn
+
+@torch.jit.script
+class BeamContainer(object):
+    def __init__(self, score: float, elem: Dict[str, Tensor]):
+        self.score = score
+        self.elem = elem
+
+    def __lt__(self, other):
+        # type: (BeamContainer) -> bool
+        # Due to https://github.com/pytorch/pytorch/issues/20388,
+        # this has to use old style type annotations
+        # Match original behavior of sorted function when two scores are equal.
+        return self.score <= other.score

--- a/fairseq/tasks/fairseq_task.py
+++ b/fairseq/tasks/fairseq_task.py
@@ -295,6 +295,7 @@ class FairseqTask(object):
             seq_gen_cls = SequenceGenerator
 
         return seq_gen_cls(
+            models,
             self.target_dictionary,
             beam_size=getattr(args, "beam", 5),
             max_len_a=getattr(args, "max_len_a", 0),

--- a/fairseq/tasks/translation_from_pretrained_bart.py
+++ b/fairseq/tasks/translation_from_pretrained_bart.py
@@ -89,6 +89,7 @@ class TranslationFromPretrainedBARTTask(TranslationTask):
         else:
             from fairseq.sequence_generator import SequenceGenerator
             return SequenceGenerator(
+                models,
                 self.target_dictionary,
                 beam_size=getattr(args, 'beam', 5),
                 max_len_a=getattr(args, 'max_len_a', 0),

--- a/tests/test_backtranslation_dataset.py
+++ b/tests/test_backtranslation_dataset.py
@@ -42,6 +42,7 @@ class TestBacktranslationDataset(unittest.TestCase):
         )
 
         generator = SequenceGenerator(
+            [self.model],
             tgt_dict=self.tgt_dict,
             max_len_a=0,
             max_len_b=200,

--- a/tests/test_sequence_generator.py
+++ b/tests/test_sequence_generator.py
@@ -4,29 +4,173 @@
 # LICENSE file in the root directory of this source tree.
 
 import argparse
+import tempfile
 import unittest
 
-import torch
-
-from fairseq import search
-from fairseq.sequence_generator import SequenceGenerator
-
 import tests.utils as test_utils
+import torch
+from fairseq import search
+from fairseq.data.dictionary import Dictionary
+
+from fairseq.models.transformer import TransformerModel
+from fairseq.sequence_generator import SequenceGenerator, EnsembleModel
+from fairseq.tasks.fairseq_task import FairseqTask
+
+
+DEFAULT_TEST_VOCAB_SIZE = 100
+
+
+class DummyTask(FairseqTask):
+    def __init__(self, args):
+        super().__init__(args)
+        self.dictionary = get_dummy_dictionary()
+        if getattr(self.args, "ctc", False):
+            self.dictionary.add_symbol("<ctc_blank>")
+        self.src_dict = self.dictionary
+        self.tgt_dict = self.dictionary
+
+    @property
+    def source_dictionary(self):
+        return self.src_dict
+
+    @property
+    def target_dictionary(self):
+        return self.dictionary
+
+
+def get_dummy_dictionary(vocab_size=DEFAULT_TEST_VOCAB_SIZE):
+    dummy_dict = Dictionary()
+    # add dummy symbol to satisfy vocab size
+    for id, _ in enumerate(range(vocab_size)):
+        dummy_dict.add_symbol("{}".format(id), 1000)
+    return dummy_dict
+
+
+def get_dummy_task_and_parser():
+    """
+    to build a fariseq model, we need some dummy parse and task. This function
+    is used to create dummy task and parser to faciliate model/criterion test
+
+    Note: we use FbSpeechRecognitionTask as the dummy task. You may want
+    to use other task by providing another function
+    """
+    parser = argparse.ArgumentParser(
+        description="test_dummy_s2s_task", argument_default=argparse.SUPPRESS
+    )
+    DummyTask.add_args(parser)
+    args = parser.parse_args([])
+    task = DummyTask.setup_task(args)
+    return task, parser
+
+
+class TestJitSequenceGeneratorBase(unittest.TestCase):
+    def setUp(self):
+        self.task, self.parser = get_dummy_task_and_parser()
+        eos = self.task.tgt_dict.eos()
+        src_tokens = torch.randint(3, 50, (2, 10)).long()
+        src_tokens = torch.cat((src_tokens, torch.LongTensor([[eos], [eos]])), -1)
+        src_lengths = torch.LongTensor([2, 10])
+        self.sample = {
+            "net_input": {"src_tokens": src_tokens, "src_lengths": src_lengths}
+        }
+        TransformerModel.add_args(self.parser)
+        args = self.parser.parse_args([])
+        args.encoder_layers = 2
+        args.decoder_layers = 1
+        self.transformer_model = TransformerModel.build_model(args, self.task)
+
+    def assertOutputEqual(self, hypo, pos_probs):
+        pos_scores = torch.FloatTensor(pos_probs).log()
+        self.assertTensorSizeEqual(hypo["positional_scores"], pos_scores)
+        self.assertTensorSizeEqual(pos_scores.numel(), hypo["tokens"].numel())
+
+    def assertTensorSizeEqual(self, t1, t2):
+        self.assertEqual(t1.size(), t2.size(), "size mismatch")
+
+    def assertAlmostEqual(self, t1, t2):
+        self.assertEqual(t1.size(), t2.size(), "size mismatch")
+        self.assertLess((t1 - t2).abs().max(), 1e-4)
+
+    def assertTensorEqual(self, t1, t2):
+        self.assertEqual(t1.size(), t2.size(), "size mismatch")
+        self.assertEqual(t1.ne(t2).long().sum(), 0)
+
+    def assertHypoEqual(self, h1, h2):
+        "Check two hypos are equal"
+        self.assertTensorEqual(h1["tokens"], h2["tokens"])
+        self.assertAlmostEqual(h1["positional_scores"], h2["positional_scores"])
+        self.assertLess(abs(h1["score"] - h2["score"]), 1e-6)
+        self.assertAlmostEqual(h1["attention"], h2["attention"])
+
+    def _test_save_and_load(self, scripted_module):
+        with tempfile.NamedTemporaryFile() as f:
+            scripted_module.save(f.name)
+            torch.jit.load(f.name)
+
+
+class TestJitSequeneceGenerator(TestJitSequenceGeneratorBase):
+    @unittest.skipIf(
+        torch.__version__ < "1.5.0", "Targeting OSS scriptability for the 1.5 release"
+    )
+    def test_export_transformer(self):
+        model = self.transformer_model
+        torch.jit.script(model)
+
+    @unittest.skipIf(
+        torch.__version__ < "1.5.0", "Targeting OSS scriptability for the 1.5 release"
+    )
+    def test_ensemble_sequence_generator(self):
+        model = self.transformer_model
+        generator = SequenceGenerator([model], self.task.tgt_dict, beam_size=2)
+        scripted_model = torch.jit.script(generator)
+        self._test_save_and_load(scripted_model)
+
+
+class TestJitEnsemble(TestJitSequenceGeneratorBase):
+    def test_export_ensemble_model(self):
+        model = self.transformer_model
+        ensemble_models = EnsembleModel([model])
+        torch.jit.script(ensemble_models)
+
+
+class TestExportSearch(unittest.TestCase):
+    def setUp(self):
+        task, _ = get_dummy_task_and_parser()
+        self.tgt_dict = task.tgt_dict
+        self.min_top1_prob = 0.4
+
+    def test_export_diverse_bs(self):
+        search_strategy = search.DiverseBeamSearch(
+            self.tgt_dict, num_groups=2, diversity_strength=0.0
+        )
+        torch.jit.script(search_strategy)
+
+    def test_export_sampling(self):
+        low_sampling_topp = self.min_top1_prob / 2.0
+        search_strategy = search.Sampling(
+            self.tgt_dict, sampling_topp=low_sampling_topp
+        )
+        torch.jit.script(search_strategy)
+
+    def test_export_diverse_siblings_search(self):
+        search_strategy = search.DiverseSiblingsSearch(
+            self.tgt_dict, diversity_rate=0.5
+        )
+        torch.jit.script(search_strategy)
 
 
 class TestSequenceGeneratorBase(unittest.TestCase):
-
     def assertHypoTokens(self, hypo, tokens):
-        self.assertTensorEqual(hypo['tokens'], torch.LongTensor(tokens))
+        self.assertTensorEqual(hypo["tokens"], torch.LongTensor(tokens))
 
-    def assertHypoScore(self, hypo, pos_probs, normalized=True, lenpen=1.):
+    def assertHypoScore(self, hypo, pos_probs, normalized=True, lenpen=1.0):
         pos_scores = torch.FloatTensor(pos_probs).log()
-        self.assertAlmostEqual(hypo['positional_scores'], pos_scores)
-        self.assertEqual(pos_scores.numel(), hypo['tokens'].numel())
+        self.assertAlmostEqual(hypo["positional_scores"], pos_scores)
+        self.assertEqual(pos_scores.numel(), hypo["tokens"].numel())
         score = pos_scores.sum()
         if normalized:
-            score /= pos_scores.numel()**lenpen
-        self.assertLess(abs(score - hypo['score']), 1e-6)
+            score /= pos_scores.numel() ** lenpen
+        self.assertLess(abs(score - hypo["score"]), 1e-6)
 
     def assertAlmostEqual(self, t1, t2):
         self.assertEqual(t1.size(), t2.size(), "size mismatch")
@@ -37,21 +181,18 @@ class TestSequenceGeneratorBase(unittest.TestCase):
         self.assertEqual(t1.ne(t2).long().sum(), 0)
 
 
-class TestSequenceGenerator(TestSequenceGeneratorBase):
-
+class TestSequeneceGenerator(TestSequenceGeneratorBase):
     def setUp(self):
         self.tgt_dict, self.w1, self.w2, src_tokens, src_lengths, self.model = (
             test_utils.sequence_generator_setup()
         )
         self.sample = {
-            'net_input': {
-                'src_tokens': src_tokens, 'src_lengths': src_lengths,
-            },
+            "net_input": {"src_tokens": src_tokens, "src_lengths": src_lengths}
         }
 
     def test_with_normalization(self):
-        generator = SequenceGenerator(self.tgt_dict, beam_size=2)
-        hypos = generator.generate([self.model], self.sample)
+        generator = SequenceGenerator([self.model], self.tgt_dict, beam_size=2)
+        hypos = generator.forward(self.sample)
         eos, w1, w2 = self.tgt_dict.eos(), self.w1, self.w2
         # sentence 1, beam 1
         self.assertHypoTokens(hypos[0][0], [w1, eos])
@@ -69,8 +210,10 @@ class TestSequenceGenerator(TestSequenceGeneratorBase):
     def test_without_normalization(self):
         # Sentence 1: unchanged from the normalized case
         # Sentence 2: beams swap order
-        generator = SequenceGenerator(self.tgt_dict, beam_size=2, normalize_scores=False)
-        hypos = generator.generate([self.model], self.sample)
+        generator = SequenceGenerator(
+            [self.model], self.tgt_dict, beam_size=2, normalize_scores=False
+        )
+        hypos = generator.forward(self.sample)
         eos, w1, w2 = self.tgt_dict.eos(), self.w1, self.w2
         # sentence 1, beam 1
         self.assertHypoTokens(hypos[0][0], [w1, eos])
@@ -87,8 +230,10 @@ class TestSequenceGenerator(TestSequenceGeneratorBase):
 
     def test_with_lenpen_favoring_short_hypos(self):
         lenpen = 0.6
-        generator = SequenceGenerator(self.tgt_dict, beam_size=2, len_penalty=lenpen)
-        hypos = generator.generate([self.model], self.sample)
+        generator = SequenceGenerator(
+            [self.model], self.tgt_dict, beam_size=2, len_penalty=lenpen
+        )
+        hypos = generator.forward(self.sample)
         eos, w1, w2 = self.tgt_dict.eos(), self.w1, self.w2
         # sentence 1, beam 1
         self.assertHypoTokens(hypos[0][0], [w1, eos])
@@ -105,8 +250,10 @@ class TestSequenceGenerator(TestSequenceGeneratorBase):
 
     def test_with_lenpen_favoring_long_hypos(self):
         lenpen = 5.0
-        generator = SequenceGenerator(self.tgt_dict, beam_size=2, len_penalty=lenpen)
-        hypos = generator.generate([self.model], self.sample)
+        generator = SequenceGenerator(
+            [self.model], self.tgt_dict, beam_size=2, len_penalty=lenpen
+        )
+        hypos = generator.forward(self.sample)
         eos, w1, w2 = self.tgt_dict.eos(), self.w1, self.w2
         # sentence 1, beam 1
         self.assertHypoTokens(hypos[0][0], [w2, w1, w2, eos])
@@ -122,8 +269,8 @@ class TestSequenceGenerator(TestSequenceGeneratorBase):
         self.assertHypoScore(hypos[1][1], [0.7, 0.4, 0.6], lenpen=lenpen)
 
     def test_maxlen(self):
-        generator = SequenceGenerator(self.tgt_dict, beam_size=2, max_len_b=2)
-        hypos = generator.generate([self.model], self.sample)
+        generator = SequenceGenerator([self.model], self.tgt_dict, beam_size=2, max_len_b=2)
+        hypos = generator.forward(self.sample)
         eos, w1, w2 = self.tgt_dict.eos(), self.w1, self.w2
         # sentence 1, beam 1
         self.assertHypoTokens(hypos[0][0], [w1, eos])
@@ -139,11 +286,11 @@ class TestSequenceGenerator(TestSequenceGeneratorBase):
         self.assertHypoScore(hypos[1][1], [0.3, 0.9, 0.01])
 
     def test_encoder_with_different_output_len(self):
-        generator = SequenceGenerator(self.tgt_dict, beam_size=2, max_len_b=2)
         args = self.model.encoder.args
         task = test_utils.TestTranslationTask.setup_task(args, self.tgt_dict, self.tgt_dict)
         reshaping_model = test_utils.TestReshapingModel.build_model(args, task)
-        hypos = generator.generate([reshaping_model], self.sample)
+        generator = SequenceGenerator([reshaping_model], self.tgt_dict, beam_size=2, max_len_b=2)
+        hypos = generator.forward(self.sample)
         for sent in [0, 1]:
             for beam in [0, 1]:
                 assert hypos[sent][beam]['attention'] is not None
@@ -210,10 +357,10 @@ class TestDiverseBeamSearch(TestSequenceGeneratorBase):
     def test_diverse_beam_search(self):
         search_strategy = search.DiverseBeamSearch(self.tgt_dict, num_groups=2, diversity_strength=0.)
         generator = SequenceGenerator(
-            self.tgt_dict, beam_size=2, search_strategy=search_strategy,
+            [self.model], self.tgt_dict, beam_size=2, search_strategy=search_strategy,
         )
         sample = {'net_input': {'src_tokens': self.src_tokens, 'src_lengths': self.src_lengths}}
-        hypos = generator.generate([self.model], sample)
+        hypos = generator.forward(sample)
         eos, w1, w2 = self.eos, self.w1, self.w2
         # sentence 1, beam 1
         self.assertHypoTokens(hypos[0][0], [w1, w1, eos])
@@ -247,7 +394,7 @@ class TestDiverseSiblingsSearch(TestDiverseBeamSearch):
             self.tgt_dict, diversity_rate=0.5
         )
         generator = SequenceGenerator(
-            self.tgt_dict, beam_size=2, search_strategy=search_strategy
+            [self.model], self.tgt_dict, beam_size=2, search_strategy=search_strategy
         )
         sample = {
             "net_input": {
@@ -255,7 +402,7 @@ class TestDiverseSiblingsSearch(TestDiverseBeamSearch):
                 "src_lengths": self.src_lengths,
             }
         }
-        hypos = generator.generate([self.model], sample)
+        hypos = generator.forward(sample)
         eos, w1, w2 = self.eos, self.w1, self.w2
         # sentence 1, beam 1
         self.assertHypoTokens(hypos[0][0], [w1, w1, eos])
@@ -338,14 +485,14 @@ class TestTopPSamplingSearch(TestSequenceGeneratorBase):
         low_sampling_topp = self.min_top1_prob/2.0
         search_strategy = search.Sampling(self.tgt_dict, sampling_topp=low_sampling_topp)
         generator = SequenceGenerator(
-            self.tgt_dict, beam_size=2, search_strategy=search_strategy)
+            [self.model], self.tgt_dict, beam_size=2, search_strategy=search_strategy)
         sample = {
             'net_input': {
                 'src_tokens': self.src_tokens,
                 'src_lengths': self.src_lengths
             }
         }
-        hypos = generator.generate([self.model], sample)
+        hypos = generator.forward(sample)
         eos, w1 = self.eos, self.w1
         # sentence 1, beam 1
         self.assertHypoTokens(hypos[0][0], [w1, w1, eos])
@@ -366,14 +513,14 @@ class TestTopPSamplingSearch(TestSequenceGeneratorBase):
         high_sampling_topp = (self.min_top1_prob+self.min_top2_prob)/2.0
         search_strategy = search.Sampling(self.tgt_dict, sampling_topp=high_sampling_topp)
         generator = SequenceGenerator(
-            self.tgt_dict, beam_size=2, search_strategy=search_strategy)
+            [self.model], self.tgt_dict, beam_size=2, search_strategy=search_strategy)
         sample = {
             'net_input': {
                 'src_tokens': self.src_tokens,
                 'src_lengths': self.src_lengths
             }
         }
-        hypos = generator.generate([self.model], sample)
+        hypos = generator.forward(sample)
         eos, w1, w2 = self.eos, self.w1, self.w2
         # sentence 1, beam 1
         self.assertTrue(self.hypoTokens(hypos[0][0], [w1, w1, eos]) or
@@ -420,5 +567,5 @@ class TestTopPSamplingSearch(TestSequenceGeneratorBase):
         return t1.size() == t2.size() and t1.ne(t2).long().sum() == 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/fairinternal/fairseq-py/pull/1120

Pull Request resolved: https://github.com/pytorch/fairseq/pull/1940

Deprecate the SequenceGenerator in Fairseq with the Scripted vision.

Pass all integration unit tests

- Copy ScriptSequenceGenerator to SequenceGenerator:
  - Modified the forward_decoder to fix bug when using adaptive_softmax in `get_prob_normalize` (marked with the inline comment)
   - Add support for other EnsembleModels as input arg (marked with the inline comment)
 - Add `FBEnsembleModelWithFork` to support folk/join in ensemblemodel
   - Add `test_fb_ensemble_model` to test folk/join feature
   - Still have bugs in folk/join feature when running in the Fairseq interface (like generation and interactive). Need further investigation P128130029. cc cndn, jhcross
- Modified SequenceGenerator initialization the interface
- Clear up the codes: delete unused functions `get_normalized_probs` and `_decode`

Reland reverted diff D20685075

Reviewed By: cndn

Differential Revision: D20895977

