### PR TITLE
Support quantization in Fairseq Sequence generator

### DIFF
--- a/fairseq/modules/multihead_attention.py
+++ b/fairseq/modules/multihead_attention.py
@@ -144,6 +144,9 @@ class MultiheadAttention(nn.Module):
             and not self.onnx_trace
             and incremental_state is None
             and not static_kv
+            # A workaround for quantization to work. Otherwise JIT compilation
+            # treats bias in linear module as method.
+            and not torch.jit.is_scripting()
         ):
             assert key is not None and value is not None
             return F.multi_head_attention_forward(

--- a/tests/test_sequence_generator.py
+++ b/tests/test_sequence_generator.py
@@ -126,6 +126,17 @@ class TestJitSequeneceGenerator(TestJitSequenceGeneratorBase):
         scripted_model = torch.jit.script(generator)
         self._test_save_and_load(scripted_model)
 
+    @unittest.skipIf(
+        torch.__version__ < "1.5.0", "Targeting OSS scriptability for the 1.5 release"
+    )
+    def test_quantized_ensemble_sequence_generator(self):
+        model = torch.quantization.quantize_dynamic(
+            self.transformer_model, {torch.nn.Linear}, dtype=torch.qint8, inplace=True
+        )
+        generator = SequenceGenerator([model], self.task.tgt_dict, beam_size=2)
+        scripted_model = torch.jit.script(generator)
+        self._test_save_and_load(scripted_model)
+
 
 class TestJitEnsemble(TestJitSequenceGeneratorBase):
 


### PR DESCRIPTION
Summary: The fix in MHA is suggested by driazati, to avoid JIT compilation for if branch in MHA forward when in scripting. Without this quantization wouldn't work. Details in https://fb.workplace.com/groups/2240361332735959/permalink/626166461295703/

Reviewed By: jhcross

Differential Revision: D20881076

