### PR TITLE
Add a new way to start speech server

### DIFF
--- a/examples/simultaneous_translation/data/yaml_to_wav_path.py
+++ b/examples/simultaneous_translation/data/yaml_to_wav_path.py
@@ -1,0 +1,24 @@
+import yaml
+import sys
+import os
+from itertools import groupby
+
+yaml_path = sys.argv[1]
+with open(yaml_path) as f:
+    wav_list = yaml.load(f, yaml.FullLoader)
+    for wav_file_name, g in groupby(wav_list, lambda x: x['wav']):
+        segment_list = list(g)
+        wav_prefix = wav_file_name.split('.')[0]
+        idx = wav_prefix.split("_")[1]
+        for i, s in enumerate(segment_list):
+            wav_name = f'{wav_prefix}_{i}.wav'
+            wav_path = os.path.abspath(
+                os.path.join(
+                    os.path.dirname(yaml_path),
+                    "..",
+                    "segmented_wav",
+                    idx,
+                    wav_name
+                )
+            )
+            sys.stdout.write(f"{wav_path}\n")

--- a/examples/simultaneous_translation/docs/evaluation.md
+++ b/examples/simultaneous_translation/docs/evaluation.md
@@ -5,22 +5,50 @@ The server provides information needed by the client and evaluates latency and q
 We use the Fairseq toolkit as an example but the evaluation process can be applied in an arbitary framework.
 
 ## Server
-The server code is provided and can be set up locally for development purposes. For example, to evaluate a text simultaneous test set,
+The server code is provided and can be set up locally for development purposes. 
+Server sends source words to client, and record the delay when receving the prediction.
+Here is an instruction on how to setup server for development.
+
+To run start a text server listening at port 12321, with `SRC_FILE` and `TGT_FILE` as raw source and target text.
 
 ```shell
-python $user_dir/eval/server.py \
+python $fairseq/example/simultaneous_translation/eval/server.py \
     --tokenizer 13a \
-    --src-file $src \
-    --tgt-file $tgt \
-    --scorer-type {text, speech} \
-    --output $result_dir/eval \
+    --src-file SRC_FILE \
+    --tgt-file TGT_FILE \
+    --scorer-type text \
+    --output $result_dir \
     --port 12321
 ```
-The `--score-type` can be either `text` or `speech` to evaluation different tasks.
 
-For text models, the `$src` and `$tgt` are the raw source and target text.
+As to speech models, if you have gone through the Data Preparation in [baseline experiment](baseline.md), you can use the json file in $DATA_ROOT/data-bin/mustc_en_de, for example, dev.json. So we can start the server
 
-For speech models, please first follow the Data Preparation [here](baseline.md) except for the binarization step. After preparation, Only `$tgt` is need, which is the json file in the data directory (for example, dev.json)
+```shell
+python $fairseq/example/simultaneous_translation/eval/server.py \
+    --tokenizer 13a \
+    --tgt-file $DATA_ROOT/data-bin/mustc_en_de/dev.json \
+    --tgt-file-type json \
+    --scorer-type speech \
+    --output $result_dir \
+    --port 12321
+```
+
+If you don't want to go though Data Preparation, you need to prepare two files:
+- TGT_FILE: the file with reference sentences
+- WAV_LIST_FILE: the file with a list of paths to WAVs, line aligned to TGT_FILE 
+
+In this case we can start the server
+```shell
+python $fairseq/example/simultaneous_translation/eval/server.py \
+    --tokenizer 13a \
+    --src-file SRC_FILE \
+    --tgt-file WAV_LIST_FILE \
+    --tgt-file-type text \
+    --scorer-type speech \
+    --output $result_dir \
+    --port 12321
+```
+
 
 The state sent to the client by the server has the following format
 ```json

--- a/examples/simultaneous_translation/docs/evaluation.md
+++ b/examples/simultaneous_translation/docs/evaluation.md
@@ -6,22 +6,22 @@ We use the Fairseq toolkit as an example but the evaluation process can be appli
 
 ## Server
 The server code is provided and can be set up locally for development purposes. 
-Server sends source words to client, and record the delay when receving the prediction.
-Here is an instruction on how to setup server for development.
+The server sends source words or speech segments to the client, and records the delay when receiving predictions.
+Here are instructions on how to setup the server for development.
 
-To run start a text server listening at port 12321, with `SRC_FILE` and `TGT_FILE` as raw source and target text.
+To run start a text server listening at port 12321, with `$SRC_FILE` and `$TGT_FILE` as raw source and target text and `$result_dir` a directory to store the results:
 
 ```shell
 python $fairseq/example/simultaneous_translation/eval/server.py \
     --tokenizer 13a \
-    --src-file SRC_FILE \
-    --tgt-file TGT_FILE \
+    --src-file $SRC_FILE \
+    --tgt-file $TGT_FILE \
     --scorer-type text \
     --output $result_dir \
     --port 12321
 ```
 
-As to speech models, if you have gone through the Data Preparation in [baseline experiment](baseline.md), you can use the json file in $DATA_ROOT/data-bin/mustc_en_de, for example, dev.json. So we can start the server
+For speech models, if you have gone through the Data Preparation in [baseline experiment](baseline.md), you can use the json file in $DATA_ROOT/data-bin/mustc_en_de, for example, dev.json. So we can start the server:
 
 ```shell
 python $fairseq/example/simultaneous_translation/eval/server.py \
@@ -34,8 +34,8 @@ python $fairseq/example/simultaneous_translation/eval/server.py \
 ```
 
 If you don't want to go though Data Preparation, you need to prepare two files:
-- TGT_FILE: the file with reference sentences
-- WAV_LIST_FILE: the file with a list of paths to WAVs, line aligned to TGT_FILE 
+- `$TGT_FILE`: the file with reference sentences
+- `$WAV_LIST_FILE`: the file with a list of paths to WAVs, line aligned to TGT_FILE 
 
 In this case we can start the server
 ```shell

--- a/examples/simultaneous_translation/eval/scorers/scorer.py
+++ b/examples/simultaneous_translation/eval/scorers/scorer.py
@@ -149,6 +149,18 @@ class SimulScorer(object):
                 )
         return list_to_return
 
+    @classmethod
+    def _load_wav_info_from_list(cls, file):
+        list_to_return = []
+        with open(file) as f:
+            for line in f:
+                list_to_return.append(
+                    {
+                        "path": line.strip(),
+                    }
+                )
+        return list_to_return
+
     def __len__(self):
         return len(self.data["tgt"])
 

--- a/examples/simultaneous_translation/eval/scorers/speech_scorers.py
+++ b/examples/simultaneous_translation/eval/scorers/speech_scorers.py
@@ -21,7 +21,7 @@ class SimulSpeechScorer(SimulScorer):
             }
         elif args.tgt_file_type == "text": 
             assert args.src_file is not None, (
-                "--src-file is needed if the --tgt-file is text\n"
+                "--src-file is needed if --tgt-file-type is text\n"
                 "--src-file should contain the path to audio "
                 "and align to the sentence in --tgt-file"
             ) 

--- a/examples/simultaneous_translation/eval/scorers/speech_scorers.py
+++ b/examples/simultaneous_translation/eval/scorers/speech_scorers.py
@@ -9,15 +9,31 @@ from . import register_scorer
 class SimulSpeechScorer(SimulScorer):
     def __init__(self, args):
         super().__init__(args)
-        if args.src_file is not None:
-            sys.stderr.write(f"src_file {args.src_file} will be ignored.\n")
+        if args.tgt_file_type == "json":
+            if args.src_file is not None:
+                sys.stderr.write(
+                    f"tgt_file type: {args.tgt_file_type}. "
+                    f"src_file {args.src_file} will be ignored.\n"
+            )
+            self.data = {
+                "src" : self._load_wav_info_from_json(args.tgt_file),
+                "tgt" : self._load_text_from_json(args.tgt_file)
+            }
+        elif args.tgt_file_type == "text": 
+            assert args.src_file is not None, (
+                "--src-file is needed if the --tgt-file is text\n"
+                "--src-file should contain the path to audio "
+                "and align to the sentence in --tgt-file"
+            ) 
+            self.data = {
+                "src" : self._load_wav_info_from_list(args.src_file),
+                "tgt" : self._load_text_file(args.tgt_file, split=False)
+            }
+        else:
+            raise NotImplementedError
 
         self.tokenizer = args.tokenizer
-        self.lengths = self._load_wav_info_from_json(args.tgt_file),
-        self.data = {
-            "src" : self._load_wav_info_from_json(args.tgt_file),
-            "tgt" : self._load_text_from_json(args.tgt_file)
-        }
+
         self.segment_size = args.segment_size
         self.sample_rate = args.sample_rate
         self.wav_data_type = args.wav_data_type
@@ -46,6 +62,12 @@ class SimulSpeechScorer(SimulScorer):
             self.data["src"][sent_id]["segments"] = self._load_audio_from_path(
                 self.data["src"][sent_id]["path"]
             ) 
+            if "length" not in self.data["src"][sent_id]:
+                length = int(sum(
+                    len(x) / self.sample_rate * 1000 
+                    for x in self.data["src"][sent_id]["segments"]
+                ))
+                self.data["src"][sent_id]["length"] = length
         
         num_segments = client_segment_size // self.segment_size
 

--- a/examples/simultaneous_translation/eval/server.py
+++ b/examples/simultaneous_translation/eval/server.py
@@ -10,6 +10,7 @@ import json
 from collections import defaultdict
 from tornado import web, ioloop
 from scorers import build_scorer
+from utils.registry import REGISTRIES 
 
 DEFAULT_HOSTNAME = 'localhost'
 DEFAULT_PORT = 12321
@@ -68,6 +69,9 @@ def add_args():
                         help='Type of data to evaluate')
     parser.add_argument('--tokenizer', default="13a", choices=["none", "13a"],
                         help='Type of data to evaluate')
+    parser.add_argument('--tgt-file-type', type=str, default="json",
+                        choices=['json', "text"],
+                        help='Type of the tgt_file, choose from json, text')
     args, _ = parser.parse_known_args()
     return args
 

--- a/examples/simultaneous_translation/eval/server.py
+++ b/examples/simultaneous_translation/eval/server.py
@@ -69,7 +69,7 @@ def add_args():
     parser.add_argument('--tokenizer', default="13a", choices=["none", "13a"],
                         help='Type of data to evaluate')
     parser.add_argument('--tgt-file-type', type=str, default="json",
-                        choices=['json', "text"],
+                        choices=['json', "text"], required=False,
                         help='Type of the tgt_file, choose from json, text')
     args, _ = parser.parse_known_args()
     return args

--- a/examples/simultaneous_translation/eval/server.py
+++ b/examples/simultaneous_translation/eval/server.py
@@ -10,7 +10,6 @@ import json
 from collections import defaultdict
 from tornado import web, ioloop
 from scorers import build_scorer
-from utils.registry import REGISTRIES 
 
 DEFAULT_HOSTNAME = 'localhost'
 DEFAULT_PORT = 12321


### PR DESCRIPTION
Add a new way to start speech  server, which might be easier for participants who didn't run the baseline experiments or is working on other framework.

The new one needs two files
- TGT_FILE: the file with reference sentences
- WAV_LIST_FILE: the file with a list of paths to WAVs, line aligned to TGT_FILE 

In this case we can start the server
```shell
python $fairseq/example/simultaneous_translation/eval/server.py \
    --tokenizer 13a \
    --src-file SRC_FILE \
    --tgt-file WAV_LIST_FILE \
    --tgt-file-type text \
    --scorer-type speech \
    --output $result_dir \
    --port 12321
```