### PR TITLE
Check for set_epoch on nested datasets

### DIFF
--- a/fairseq/data/nested_dictionary_dataset.py
+++ b/fairseq/data/nested_dictionary_dataset.py
@@ -113,4 +113,5 @@ class NestedDictionaryDataset(FairseqDataset):
     def set_epoch(self, epoch):
         super().set_epoch(epoch)
         for ds in self.defn.values():
-            ds.set_epoch(epoch)
+            if hasattr(ds, 'set_epoch'):
+                ds.set_epoch(epoch)


### PR DESCRIPTION
Checks for set_epoch on nested datasets in NestedDictionaryDataset, same/similar issue as https://github.com/pytorch/fairseq/issues/989