### PR TITLE
add local evaluation for simultaneous translation

### DIFF
--- a/examples/simultaneous_translation/eval/agents/agent.py
+++ b/examples/simultaneous_translation/eval/agents/agent.py
@@ -1,11 +1,14 @@
 from . import GET, SEND, DEFAULT_EOS
 import time
 from multiprocessing.pool import ThreadPool as Pool
-from functools import partial 
+from functools import partial
+
+
 class Agent(object):
     "an agent needs to follow this pattern"
     def __init__(self, *args, **kwargs):
         pass
+
     def init_states(self, *args, **kwargs):
         raise NotImplementedError
 
@@ -20,7 +23,7 @@ class Agent(object):
 
     def reset(self):
         raise NotImplementedError
-        
+
     def decode(self, session, low=0, high=100000, num_thread=10):
         corpus_info = session.corpus_info()
         high = min(corpus_info["num_sentences"] - 1, high)

--- a/examples/simultaneous_translation/eval/agents/simul_trans_agent.py
+++ b/examples/simultaneous_translation/eval/agents/simul_trans_agent.py
@@ -5,6 +5,7 @@ import torch
 from fairseq import checkpoint_utils, utils, tasks
 import os
 
+
 class SimulTransAgent(Agent):
     def __init__(self, args):
         # Load Model
@@ -19,7 +20,7 @@ class SimulTransAgent(Agent):
 
     @staticmethod
     def add_args(parser):
-        parser.add_argument('--model-path', type=str, default=None, 
+        parser.add_argument('--model-path', type=str, default=None,
                             help='path to your pretrained model.')
         parser.add_argument("--data-bin", type=str, required=True,
                             help="Path of data binary")
@@ -43,7 +44,7 @@ class SimulTransAgent(Agent):
                         help='a dictionary used to override model args at generation '
                                 'that were used during model training')
         return parser
-    
+
     def load_dictionary(self, task):
         raise NotImplementedError
 
@@ -98,7 +99,7 @@ class SimulTransAgent(Agent):
                 # READ
                 action = self.read_action(states)
             else:
-                # WRITE 
+                # WRITE
                 action = self.write_action(states)
 
             # None means we make decision again but not sending server anything
@@ -117,12 +118,12 @@ class SimulTransAgent(Agent):
             states["finished"] = True
             end_idx_last_full_word = self._target_length(states)
 
-        else:    
+        else:
             states["tokens"]["tgt"] += [token]
             end_idx_last_full_word = (
                 self.word_splitter["tgt"]
                 .end_idx_last_full_word(states["tokens"]["tgt"])
-            ) 
+            )
             self._append_indices(states, [index], "tgt")
 
         if end_idx_last_full_word > states["steps"]["tgt"]:
@@ -133,7 +134,7 @@ class SimulTransAgent(Agent):
                 ]
             )
             states["steps"]["tgt"] = end_idx_last_full_word
-            states["segments"]["tgt"] += [word] 
+            states["segments"]["tgt"] += [word]
 
             return {'key': SEND, 'value': word}
         else:
@@ -152,9 +153,9 @@ class SimulTransAgent(Agent):
         if len(new_state) == 0 and len(states["indices"]["src"]) == 0:
             return True
         return False
-        
+
     def _append_indices(self, states, new_indices, key):
         states["indices"][key] += new_indices
-    
+
     def _target_length(self, states):
         return len(states["tokens"]['tgt'])

--- a/examples/simultaneous_translation/eval/client.py
+++ b/examples/simultaneous_translation/eval/client.py
@@ -19,14 +19,14 @@ class SimulSTEvaluationService(object):
         pass
 
     def new_session(self):
-        # start eval session    
+        # start eval session
         url = f'{self.base_url}'
-        
+
         try:
             _ = requests.post(url)
         except Exception as e:
             print(f'Failed to start an evaluation session: {e}')
-        
+
         print('Evaluation session started.')
         return self
 
@@ -39,12 +39,11 @@ class SimulSTEvaluationService(object):
             print('Evaluation session finished.')
         except Exception as e:
             print(f'Failed to end an evaluation session: {e}')
-        
-        
+
     def get_src(self, sent_id: int, extra_params: Optional[dict] = None) -> str:
         url = f'{self.base_url}/src'
         params = {"sent_id": sent_id}
-        if extra_params is not None:    
+        if extra_params is not None:
             for key in extra_params.keys():
                 params[key] = extra_params[key]
         try:
@@ -71,10 +70,28 @@ class SimulSTEvaluationService(object):
             r = requests.get(url)
         except Exception as e:
             print(f'Failed to request corpus information: {e}')
-            
+
         return r.json()
 
 
+class SimulSTLocalEvaluationService(object):
+    def __init__(self, scorer):
+        self.scorer = scorer
 
+    def get_scores(self):
+        return self.scorer.score()
 
+    def get_src(self, sent_id: int, extra_params: Optional[dict] = None) -> str:
+        if extra_params is not None:
+            segment_size = extra_params.get("segment_size", None)
+        else:
+            segment_size = None
 
+        return self.scorer.send_src(int(sent_id), segment_size)
+
+    def send_hypo(self, sent_id: int, hypo: str) -> None:
+        list_of_tokens = hypo.strip().split()
+        self.scorer.recv_hyp(sent_id, list_of_tokens)
+
+    def corpus_info(self):
+        return self.scorer.get_info()

--- a/examples/simultaneous_translation/eval/evaluate_local.py
+++ b/examples/simultaneous_translation/eval/evaluate_local.py
@@ -1,0 +1,51 @@
+import argparse
+
+import sys
+from client import SimulSTEvaluationService, SimulSTLocalEvaluationService
+from agents import build_agent
+from agents.registry import REGISTRIES
+from scorers import build_scorer
+
+def get_args():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--agent-type', default=None,
+                        help='Agent type')
+    parser.add_argument('--scorer-type', type=str, default="text", choices=["text", "speech"],
+                        help='Type of data to evaluate')
+    parser.add_argument('--num-threads', type=int, default=10,
+                        help='Number of threads used by agent')
+    parser.add_argument('--src-file', type=str,
+                        help='Source file')
+    parser.add_argument('--tgt-file', type=str,
+                        help='Target file')
+    parser.add_argument('--output', type=str,
+                        help='Directory to leave output')
+    parser.add_argument('--tokenizer', default="13a", choices=["none", "13a"],
+                        help='Type of data to evaluate')
+    parser.add_argument('--tgt-file-type', type=str, default="json",
+                        choices=['json', "text"], required=False,
+                        help='Type of the tgt_file, choose from json, text')
+    parser.add_argument('--debug', action='store_true', help='debug mode')
+
+    args, _ = parser.parse_known_args()
+    for registry_name, REGISTRY in REGISTRIES.items():
+        choice = getattr(args, registry_name, None)
+        if choice is not None:
+            cls = REGISTRY['registry'][choice]
+            if hasattr(cls, 'add_args'):
+                cls.add_args(parser)
+    args = parser.parse_args()
+
+    return args
+
+if __name__ == "__main__":
+    args = get_args()
+    scorer = build_scorer(args)
+    session = SimulSTLocalEvaluationService(scorer)
+
+    if args.agent_type is not None:
+        agent = build_agent(args)
+        agent.decode(session, num_thread=args.num_threads)
+
+    print(session.get_scores())

--- a/examples/simultaneous_translation/eval/scorers/text_scorers.py
+++ b/examples/simultaneous_translation/eval/scorers/text_scorers.py
@@ -6,8 +6,8 @@ class SimulTextScorer(SimulScorer):
     def __init__(self, args):
         super().__init__(args)
         self.data = {
-            "src" : self._load_text_file(args.src_file, split=True),
-            "tgt" : self._load_text_file(args.tgt_file, split=False)
+            "src": self._load_text_file(args.src_file, split=True),
+            "tgt": self._load_text_file(args.tgt_file, split=False)
         }
 
     def send_src(self, sent_id, *args):
@@ -18,7 +18,7 @@ class SimulTextScorer(SimulScorer):
                 "segment": self.eos
             }
             # Consider EOS
-            self.steps[sent_id] = len(self.data["src"][sent_id]) + 1 
+            self.steps[sent_id] = len(self.data["src"][sent_id]) + 1
         else:
             dict_to_return = {
                 "sent_id" : sent_id,

--- a/examples/simultaneous_translation/scripts/start-local-eval.sh
+++ b/examples/simultaneous_translation/scripts/start-local-eval.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+config=$1
+. $1
+
+model=$2
+
+if [ $scorer_type = "text" ]
+then
+    num_test=$(wc -l $src | cut -d " " -f1)
+else
+    num_test=$(grep length_ms $tgt | wc -l)
+fi
+echo $num_test
+
+chunk_size=300
+num_chunk=$((num_test / chunk_size))
+echo Config: $(realpath $config)
+echo Model: $(realpath $model)
+echo Source: $src
+echo Target: $tgt
+echo Tokenizer: $tokenizer
+echo Agent: $agent_type
+
+user_dir=$(dirname "$0")/..
+
+echo Evaluatation starts at $(date +%Y/%m/%d-%H:%M:%S) &&
+python $user_dir/eval/evaluate_local.py \
+    --scorer-type $scorer_type \
+    --agent-type $agent_type \
+    --tokenizer $tokenizer \
+    --src-file $src \
+    --tgt-file $tgt \
+    --data-bin $data_bin \
+    --model-path $model \
+    --src-splitter-type $src_splitter_type \
+    --src-splitter-path $src_splitter_path \
+    --tgt-splitter-type $tgt_splitter_type \
+    --tgt-splitter-path $tgt_splitter_path \
+    --num-threads 10
+echo Evaluation ends at $(date +%Y/%m/%d-%H:%M:%S)
+
+
+


### PR DESCRIPTION
Usage:

- Text Translation

``` shell
python $fairseq/example/simultaneous_translation/eval/evaluate_local.py \
    --scorer-type text \
    --agent-type simul_trans_text \
    --tokenizer 13a \
    --src-file $src \
    --tgt-file $tgt \
    --data-bin $data_bin \
    --model-path $model \
    --src-splitter-type $src_splitter_type \
    --src-splitter-path $src_splitter_path \
    --tgt-splitter-type $tgt_splitter_type \
    --tgt-splitter-path $tgt_splitter_path \
    --num-threads 10 \
    --output
```
- Speech Translation

``` shell
python $fairseq/example/simultaneous_translation/eval/evaluate_local.py \
    --scorer-type speech \
    --agent-type simul_trans_speech \
    --tokenizer 13a \
    --tgt-file $json_file \
    --data-bin $data_bin \
    --model-path $model \
    --src-splitter-type $src_splitter_type \
    --src-splitter-path $src_splitter_path \
    --tgt-splitter-type $tgt_splitter_type \
    --tgt-splitter-path $tgt_splitter_path \
    --num-threads 10 \
    --output
```