### PR TITLE
Modify gated unit tests to fix Fairseq OSS

### DIFF
--- a/tests/test_sequence_generator.py
+++ b/tests/test_sequence_generator.py
@@ -118,7 +118,7 @@ class TestJitSequeneceGenerator(TestJitSequenceGeneratorBase):
         torch.jit.script(model)
 
     @unittest.skipIf(
-        torch.__version__ < "1.5.0", "Targeting OSS scriptability for the 1.5 release"
+        torch.__version__ < "1.6.0", "Targeting OSS scriptability for the 1.6 release"
     )
     def test_ensemble_sequence_generator(self):
         model = self.transformer_model
@@ -128,22 +128,11 @@ class TestJitSequeneceGenerator(TestJitSequenceGeneratorBase):
         scripted_model = torch.jit.script(generator)
         self._test_save_and_load(scripted_model)
 
-    @unittest.skipIf(
-        torch.__version__ < "1.5.0", "Targeting OSS scriptability for the 1.5 release"
-    )
-    def test_quantized_ensemble_sequence_generator(self):
-        model = torch.quantization.quantize_dynamic(
-            self.transformer_model, {torch.nn.Linear}, dtype=torch.qint8, inplace=True
-        )
-        generator = SequenceGenerator([model], self.task.tgt_dict, beam_size=2)
-        scripted_model = torch.jit.script(generator)
-        self._test_save_and_load(scripted_model)
-
 
 class TestJitEnsemble(TestJitSequenceGeneratorBase):
 
     @unittest.skipIf(
-        torch.__version__ < "1.5.0", "Targeting OSS scriptability for the 1.5 release"
+        torch.__version__ < "1.6.0", "Targeting OSS scriptability for the 1.6 release"
     )
     def test_export_ensemble_model(self):
         model = self.transformer_model


### PR DESCRIPTION
Summary:
test_ensemble_sequence_generator is green on fbcode master but Pytorch 1.5 release cut happened before the TorchScript fix, so updating the gate to 1.6
Remove quantization test from fairseq as FBGEMMS is binded at OSS side. Will add the test back in fbtranslate but land this first to fix OSS side failures.

Differential Revision: D21231873

