### PR TITLE
Refactor fb_sequence_generator for TS models to work with multithreading

### DIFF
--- a/fairseq/models/transformer.py
+++ b/fairseq/models/transformer.py
@@ -697,11 +697,6 @@ class TransformerDecoder(FairseqIncrementalDecoder):
                 factor=args.adaptive_softmax_factor,
                 tie_proj=args.tie_adaptive_proj,
             )
-        elif not self.share_input_output_embed:
-            self.embed_out = nn.Parameter(
-                torch.Tensor(len(dictionary), self.output_embed_dim)
-            )
-            nn.init.normal_(self.embed_out, mean=0, std=self.output_embed_dim ** -0.5)
 
         if args.decoder_normalize_before and not getattr(
             args, "no_decoder_final_norm", False
@@ -713,6 +708,16 @@ class TransformerDecoder(FairseqIncrementalDecoder):
             self.layernorm_embedding = LayerNorm(embed_dim)
         else:
             self.layernorm_embedding = None
+
+        if self.share_input_output_embed:
+            self.output_projection = nn.Linear(
+                self.embed_tokens.weight.shape[1], self.embed_tokens.weight.shape[0], bias=False
+            )
+        else:
+            self.output_projection = nn.Linear(
+                self.output_embed_dim, len(dictionary), bias=False
+            )
+            nn.init.normal_(self.output_projection.weight, mean=0, std=self.output_embed_dim ** -0.5)
 
     def build_decoder_layer(self, args, no_encoder_attn=False):
         return TransformerDecoderLayer(args, no_encoder_attn)
@@ -883,10 +888,7 @@ class TransformerDecoder(FairseqIncrementalDecoder):
         """Project features to the vocabulary size."""
         if self.adaptive_softmax is None:
             # project back to size of vocabulary
-            if self.share_input_output_embed:
-                return F.linear(features, self.embed_tokens.weight)
-            else:
-                return F.linear(features, self.embed_out)
+            return self.output_projection(features)
         else:
             return features
 
@@ -920,6 +922,18 @@ class TransformerDecoder(FairseqIncrementalDecoder):
             state_dict[
                 "{}.embed_positions._float_tensor".format(name)
             ] = torch.FloatTensor(1)
+
+        embed_tokens_weights_key = f"{name}.embed_tokens.weights"
+        embed_out_key = f"{name}.embed_out"
+        if embed_tokens_weights_key in state_dict:
+            state_dict[f"{name}.output_projection.weight"] = state_dict[
+                embed_tokens_weights_key
+            ]
+        if embed_out_key in state_dict:
+            state_dict[f"{name}.output_projection.weight"] = state_dict[
+                embed_out_key
+            ]
+            del state_dict[embed_out_key]
 
         for i in range(self.num_layers):
             # update layer norms

--- a/fairseq/search.py
+++ b/fairseq/search.py
@@ -62,7 +62,7 @@ class BeamSearch(Search):
         else:
             # make probs contain cumulative scores for each hypothesis
             assert scores is not None
-            lprobs.add_(scores[:, :, step - 1].unsqueeze(-1))
+            lprobs = lprobs.add(scores[:, :, step - 1].unsqueeze(-1))
 
         top_prediction = torch.topk(
             lprobs.view(bsz, -1),
@@ -76,7 +76,7 @@ class BeamSearch(Search):
         scores_buf = top_prediction[0]
         indices_buf = top_prediction[1]
         beams_buf = torch.div(indices_buf, vocab_size)
-        indices_buf.fmod_(vocab_size)
+        indices_buf = indices_buf.fmod(vocab_size)
         return scores_buf, indices_buf, beams_buf
 
 

--- a/fairseq/sequence_generator.py
+++ b/fairseq/sequence_generator.py
@@ -461,7 +461,7 @@ class SequenceGenerator(nn.Module):
         prefix_lprobs = lprobs.gather(-1, prefix_toks.unsqueeze(-1))
         prefix_mask = prefix_toks.ne(self.pad)
         lprobs[prefix_mask] = torch.tensor(-math.inf).to(lprobs)
-        lprobs[prefix_mask] = lprobs[prefix_mask].scatter_(
+        lprobs[prefix_mask] = lprobs[prefix_mask].scatter(
             -1, prefix_toks[prefix_mask].unsqueeze(-1), prefix_lprobs[prefix_mask]
         )
         # if prefix includes eos, then we should make sure tokens and


### PR DESCRIPTION
Summary:
Now I separate out the forward pass from SequenceGenerator. 2 changes to make exported TS model work under multithreading settings.
1. Avoid stateful attribute including incremental states, src_lengths in EnsembleModel / SequenceGenerator. This is the main reason I hesitated to merge with the original version. myleott, is there specific reason why we have incremental states as module attributes, instead of initializing it in forward pass?
2. Replace in place operator with out of place equivalent. This caused a bit of code bloat, mostly for index_put operators

e.g.
    eos_mask[:, :beam_size][blacklist] = torch.tensor(0).to(eos_mask)

becomes

    slices = torch.arange(eos_mask.numel()).view(eos_mask.shape)[:, :beam_size][
                blacklist
            ]
    eos_mask = eos_mask.index_put([slices], torch.tensor(0).to(eos_mask))

Differential Revision: D20995796

