### PR TITLE
Override reorder_incremental_states in fairseq transformer

### DIFF
--- a/fairseq/models/transformer.py
+++ b/fairseq/models/transformer.py
@@ -964,6 +964,17 @@ class TransformerDecoder(FairseqIncrementalDecoder):
 
         return state_dict
 
+    # Overwrite the method to temporaily support JIT scripting in Transformer
+    @torch.jit.export
+    def reorder_incremental_state(
+        self,
+        incremental_state: Dict[str, Dict[str, Optional[Tensor]]],
+        new_order: Tensor,
+    ):
+        """Scriptable reorder incremental state in the transformer."""
+        for layer in self.layers:
+            layer.reorder_incremental_state(incremental_state, new_order)
+
 
 def Embedding(num_embeddings, embedding_dim, padding_idx):
     m = nn.Embedding(num_embeddings, embedding_dim, padding_idx=padding_idx)

--- a/fairseq/modules/multihead_attention.py
+++ b/fairseq/modules/multihead_attention.py
@@ -313,7 +313,14 @@ class MultiheadAttention(nn.Module):
                     dim=1,
                 )
 
+        print("q")
+        print(q.sum())
+        print("k")
+        print(k.sum())
+
         attn_weights = torch.bmm(q, k.transpose(1, 2))
+        print("attn_weights")
+        print(attn_weights.sum())
         attn_weights = MultiheadAttention.apply_sparse_mask(attn_weights, tgt_len, src_len, bsz)
 
         assert list(attn_weights.size()) == [bsz * self.num_heads, tgt_len, src_len]

--- a/fairseq/modules/transformer_layer.py
+++ b/fairseq/modules/transformer_layer.py
@@ -379,6 +379,18 @@ class TransformerDecoderLayer(nn.Module):
     def make_generation_fast_(self, need_attn: bool = False, **kwargs):
         self.need_attn = need_attn
 
+    @torch.jit.export
+    def reorder_incremental_state(
+        self,
+        incremental_state: Dict[str, Dict[str, Optional[Tensor]]],
+        new_order: Tensor,
+    ):
+        """Scriptable reorder incremental state in transformer layers."""
+        self.self_attn.reorder_incremental_state(incremental_state, new_order)
+
+        if self.encoder_attn is not None:
+            self.encoder_attn.reorder_incremental_state(incremental_state, new_order)
+
 
 def Linear(in_features, out_features, bias=True):
     m = nn.Linear(in_features, out_features, bias)

--- a/fairseq/search.py
+++ b/fairseq/search.py
@@ -62,7 +62,7 @@ class BeamSearch(Search):
         else:
             # make probs contain cumulative scores for each hypothesis
             assert scores is not None
-            lprobs.add_(scores[:, :, step - 1].unsqueeze(-1))
+            lprobs = lprobs + scores[:, :, step - 1].unsqueeze(-1)
 
         top_prediction = torch.topk(
             lprobs.view(bsz, -1),
@@ -76,7 +76,7 @@ class BeamSearch(Search):
         scores_buf = top_prediction[0]
         indices_buf = top_prediction[1]
         beams_buf = torch.div(indices_buf, vocab_size)
-        indices_buf.fmod_(vocab_size)
+        indices_buf = indices_buf.fmod(vocab_size)
         return scores_buf, indices_buf, beams_buf
 
 

--- a/fairseq/sequence_generator.py
+++ b/fairseq/sequence_generator.py
@@ -461,7 +461,7 @@ class SequenceGenerator(nn.Module):
         prefix_lprobs = lprobs.gather(-1, prefix_toks.unsqueeze(-1))
         prefix_mask = prefix_toks.ne(self.pad)
         lprobs[prefix_mask] = torch.tensor(-math.inf).to(lprobs)
-        lprobs[prefix_mask] = lprobs[prefix_mask].scatter_(
+        lprobs[prefix_mask] = lprobs[prefix_mask].scatter(
             -1, prefix_toks[prefix_mask].unsqueeze(-1), prefix_lprobs[prefix_mask]
         )
         # if prefix includes eos, then we should make sure tokens and

--- a/fairseq/sequence_generator.py
+++ b/fairseq/sequence_generator.py
@@ -261,7 +261,7 @@ class SequenceGenerator(nn.Module):
         batch_idxs: Optional[Tensor] = None
         for step in range(max_len + 1):  # one extra step for EOS marker
             # reorder decoder internal states based on the prev choice of beams
-            # print(f'step: {step}')
+            print(f'step: {step}')
             if reorder_state is not None:
                 if batch_idxs is not None:
                     # update beam indices to take into account removed sentences


### PR DESCRIPTION
Summary:
We identified issues in TorchScript builtin hasattr occasionally has inconsistency so reorder_incremental_state is not always triggered in exported model. We had these overrides once before named_module / id were supported in TorchScript and Chen removed in D20896200. Plan to have these until hasattr issue gets fixed.

With this we observed ~1 bleu score regression is gone, see test plan.

Differential Revision: D21273014

