### PR TITLE
Make Dictionary constructor arguments keyword-only

### DIFF
--- a/fairseq/data/dictionary.py
+++ b/fairseq/data/dictionary.py
@@ -19,6 +19,7 @@ class Dictionary(object):
 
     def __init__(
         self,
+        *,  # begin keyword-only arguments
         pad="<pad>",
         eos="</s>",
         unk="<unk>",

--- a/fairseq/data/legacy/masked_lm_dictionary.py
+++ b/fairseq/data/legacy/masked_lm_dictionary.py
@@ -18,7 +18,7 @@ class MaskedLMDictionary(Dictionary):
         unk='<unk>',
         mask='<mask>',
     ):
-        super().__init__(pad, eos, unk)
+        super().__init__(pad=pad, eos=eos, unk=unk)
         self.mask_word = mask
         self.mask_index = self.add_symbol(mask)
         self.nspecial = len(self.symbols)
@@ -42,7 +42,7 @@ class BertDictionary(MaskedLMDictionary):
         cls='<cls>',
         sep='<sep>'
     ):
-        super().__init__(pad, eos, unk, mask)
+        super().__init__(pad=pad, eos=eos, unk=unk)
         self.cls_word = cls
         self.sep_word = sep
         self.cls_index = self.add_symbol(cls)


### PR DESCRIPTION
This is a minor safety thing, since otherwise it may be tempting to call `Dictionary(filename)` instead of `Dictionary.load(filename)`. After this change, all arguments to `Dictionary.__init__` must be given explicitly.