### PR TITLE
Remove unused bias_kv/zero_attn options from TransformerSentenceEncod…

### DIFF
--- a/fairseq/modules/transformer_sentence_encoder_layer.py
+++ b/fairseq/modules/transformer_sentence_encoder_layer.py
@@ -47,8 +47,6 @@ class TransformerSentenceEncoderLayer(nn.Module):
             self.embedding_dim,
             num_attention_heads,
             dropout=attention_dropout,
-            add_bias_kv=False,
-            add_zero_attn=False,
             self_attention=True,
             q_noise=q_noise,
             qn_block_size=qn_block_size,


### PR DESCRIPTION
…erLayer #1893

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  


