### PR TITLE
Fix EOS token in multilingual_denoising

### DIFF
--- a/fairseq/data/data_utils.py
+++ b/fairseq/data/data_utils.py
@@ -38,7 +38,12 @@ def collate_tokens(values, pad_idx, eos_idx=None, left_pad=False, move_eos_to_be
     def copy_tensor(src, dst):
         assert dst.numel() == src.numel()
         if move_eos_to_beginning:
-            dst[0] = eos_idx
+            # if no eos_idx is specified, then use the last token in src
+            if eos_idx is None:
+                dst[0] = src[-1]
+            # else use the given eos_idx
+            else:
+                dst[0] = eos_idx
             dst[1:] = src[:-1]
         else:
             dst.copy_(src)

--- a/fairseq/data/denoising_dataset.py
+++ b/fairseq/data/denoising_dataset.py
@@ -26,7 +26,9 @@ def collate(
     def merge(key, left_pad, move_eos_to_beginning=False):
         return data_utils.collate_tokens(
             [s[key] for s in samples],
-            pad_idx, eos_idx, left_pad, move_eos_to_beginning,
+            pad_idx=vocab.pad(),
+            eos_idx=None,  # use eos_idx of each sample instead of vocab.eos()
+            left_pad=left_pad, move_eos_to_beginning=move_eos_to_beginning,
         )
 
     id = torch.LongTensor([s['id'] for s in samples])

--- a/fairseq/data/denoising_dataset.py
+++ b/fairseq/data/denoising_dataset.py
@@ -352,7 +352,7 @@ class DenoisingDataset(FairseqDataset):
         Returns:
             dict: a mini-batch of data
         """
-        return collate(samples, self.vocab.pad(), self.vocab.eos(), self.vocab)
+        return collate(samples, self.vocab.pad(), self.eos, self.vocab)
 
     def num_tokens(self, index):
         """Return the number of tokens in a sample. This value is used to


### PR DESCRIPTION
Fixes https://github.com/pytorch/fairseq/issues/1785, where in multilingual_denoising the generic eos token is used instead of the `langid` token. 

Specifically, the problem is that the [collater](https://github.com/pytorch/fairseq/blob/master/fairseq/data/denoising_dataset.py#L355) in the denoising_dataset uses the generic `self.vocab.eos()` instead of `self.eos`, which in the case of `multilingual_denoising` is [set](https://github.com/pytorch/fairseq/blob/master/fairseq/tasks/multilingual_denoising.py#L159) to the language id of a given language.

See https://github.com/pytorch/fairseq/issues/1785#issuecomment-626171602 for an example of the issue.