### PR TITLE
Check if the checkpoint is from the latest version before updating the state_dict in TransformerDecoder.upgrade_state_dict_named()

### DIFF
--- a/fairseq/models/transformer.py
+++ b/fairseq/models/transformer.py
@@ -819,14 +819,15 @@ class TransformerDecoder(FairseqIncrementalDecoder):
                 "{}.embed_positions._float_tensor".format(name)
             ] = torch.FloatTensor(1)
 
-        if self.share_input_output_embed:
-            embed_out_key = f"{name}.embed_tokens.weight"
-        else:
-            embed_out_key = f"{name}.embed_out"
-        if embed_out_key in state_dict:
-            state_dict[f"{name}.output_projection.weight"] = state_dict[embed_out_key]
-            if not self.share_input_output_embed:
-                del state_dict[embed_out_key]
+        if f"{name}.output_projection.weight" not in state_dict:
+            if self.share_input_output_embed:
+                embed_out_key = f"{name}.embed_tokens.weight"
+            else:
+                embed_out_key = f"{name}.embed_out"
+            if embed_out_key in state_dict:
+                state_dict[f"{name}.output_projection.weight"] = state_dict[embed_out_key]
+                if not self.share_input_output_embed:
+                    del state_dict[embed_out_key]
 
         for i in range(self.num_layers):
             # update layer norms


### PR DESCRIPTION
Summary:
When share_input_output_embed is set to True, the existing code always overrides output_projection.weight with embed_tokens.weight

This is unncessary, and caused a very obscure bug in our custom BART model.

Added a check to skip the update to state_dict if f"{name}.output_projection.weight" is already in the checkpoint.

Reviewed By: myleott

Differential Revision: D21915833

