### PR TITLE
add maybe_no_sync for multilingual_translation task

### DIFF
--- a/fairseq/tasks/multilingual_translation.py
+++ b/fairseq/tasks/multilingual_translation.py
@@ -7,6 +7,7 @@ from collections import OrderedDict
 import logging
 import os
 
+import contextlib
 import torch
 
 from fairseq import metrics, options
@@ -265,13 +266,24 @@ class MultilingualTranslationTask(FairseqTask):
         model.train()
         from collections import defaultdict
         agg_loss, agg_sample_size, agg_logging_output = 0., 0., defaultdict(float)
-        for lang_pair in self.model_lang_pairs:
-            if sample[lang_pair] is None or len(sample[lang_pair]) == 0:
-                continue
-            loss, sample_size, logging_output = criterion(model.models[lang_pair], sample[lang_pair])
-            if ignore_grad:
-                loss *= 0
-            optimizer.backward(loss)
+        curr_lang_pairs = [lang_pair for lang_pair in self.model_lang_pairs \
+                if sample[lang_pair] is not None and len(sample[lang_pair]) != 0]
+
+        for idx, lang_pair in enumerate(curr_lang_pairs):
+            def maybe_no_sync():
+                if (
+                    self.args.distributed_world_size > 1
+                    and hasattr(model, 'no_sync')
+                    and idx < len(curr_lang_pairs) - 1
+                ):
+                    return model.no_sync()
+                else:
+                    return contextlib.ExitStack()  # dummy contextmanager
+            with maybe_no_sync():
+                loss, sample_size, logging_output = criterion(model.models[lang_pair], sample[lang_pair])
+                if ignore_grad:
+                    loss *= 0
+                optimizer.backward(loss)
             agg_loss += loss.detach().item()
             # TODO make summing of the sample sizes configurable
             agg_sample_size += sample_size


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [ x ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- [ x ] Did you write any new necessary tests?  

## What does this PR do?
This PR reduces unnecessary communication overhead between GPUs since we only need to sync up once for all lang-pairs. We see significant training speedup especially with large number of lang-pairs.
