### PR TITLE
adjust parameter definition with right order.

### DIFF
--- a/fairseq/models/transformer.py
+++ b/fairseq/models/transformer.py
@@ -330,6 +330,11 @@ class TransformerEncoder(FairseqEncoder):
             if not args.no_token_positional_embeddings
             else None
         )
+        
+        if getattr(args, "layernorm_embedding", False):
+            self.layernorm_embedding = LayerNorm(embed_dim)
+        else:
+            self.layernorm_embedding = None
 
         if not args.adaptive_input and args.quant_noise_pq > 0:
             self.quant_noise = apply_quant_noise_(
@@ -353,10 +358,6 @@ class TransformerEncoder(FairseqEncoder):
             self.layer_norm = LayerNorm(embed_dim)
         else:
             self.layer_norm = None
-        if getattr(args, "layernorm_embedding", False):
-            self.layernorm_embedding = LayerNorm(embed_dim)
-        else:
-            self.layernorm_embedding = None
 
     def build_encoder_layer(self, args):
         return TransformerEncoderLayer(args)


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  

## What does this PR do?

Before this commit, fairseq **log** is as follows, which may confuse us with `layernorm_embedding`

```
  (encoder): TransformerEncoder(
    (embed_tokens): Embedding(21128, 768, padding_idx=0)
    (embed_positions): LearnedPositionalEmbedding(512, 768, padding_idx=0)
    (layers): ModuleList(
      (0): ...
      (1): ...
      (2): 
      (3): 
      (4): 
      (5): 
    )
    (layernorm_embedding): LayerNorm((768,), eps=1e-05, elementwise_affine=True)  # ----- wrong order ----
  )
```

After this commit

```
  (encoder): TransformerEncoder(
    (embed_tokens): Embedding(21128, 768, padding_idx=0)
    (embed_positions): LearnedPositionalEmbedding(512, 768, padding_idx=0)
    (layernorm_embedding): LayerNorm((768,), eps=1e-05, elementwise_affine=True)  # ----- right order ----
    (layers): ModuleList(
      (0): ...
      (1): ...
      (2): 
      (3): 
      (4): 
      (5): 
    )
  )
```


## Related src code

 `layernorm_embedding` is applied before self-attention layer

https://github.com/pytorch/fairseq/blob/894ae64858b62927d849c0fbc05e8f55d680a4f1/fairseq/models/transformer.py#L364-L372



## Did you have fun?
Make sure you had fun coding 🙃
