### PR TITLE
Fix UnicodeEncodeError with fairseq-generate (#2287)

### DIFF
--- a/fairseq_cli/generate.py
+++ b/fairseq_cli/generate.py
@@ -30,7 +30,7 @@ def main(args):
     if args.results_path is not None:
         os.makedirs(args.results_path, exist_ok=True)
         output_path = os.path.join(args.results_path, 'generate-{}.txt'.format(args.gen_subset))
-        with open(output_path, 'w', buffering=1) as h:
+        with open(output_path, 'w', buffering=1, encoding='utf-8') as h:
             return _main(args, h)
     else:
         return _main(args, sys.stdout)


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?  (n/a)
- [x] Did you write any new necessary tests?  (n/a)

## What does this PR do?
Fixes #2287 where a file `open` without encoding would cause a `UnicodeEncodeError` when using `fairseq-generate` with Unicode characters on Windows. A similar change was made in #460 but this line seems to have been added after that PR.

## Notes for similar future fixes
The repo has some other calls to `open` with non-binary files (i.e. mode is not `rb` or `wb`) that may cause similar issues. Perhaps there could be a codemod to inject encoding into all of these call sites, unless there are situations in this repo where text files should have a different encoding? Alternatively or in addition, perhaps a linter rule/plugin could be added to check for this case like this one: https://pypi.org/project/flake8-file-encoding/.
