### PR TITLE
fixed wav2vec example README.md

### DIFF
--- a/examples/wav2vec/README.md
+++ b/examples/wav2vec/README.md
@@ -30,7 +30,7 @@ Given a directory containing wav files to be used for pretraining (we recommend 
 ### Prepare training data manifest:
 
 ```
-$ python scripts/wav2vec_manifest.py /path/to/waves --dest /manifest/path --ext wav
+$ python examples/wav2vec/wav2vec_manifest.py /path/to/waves --dest /manifest/path --ext wav
 ```
 
 ### Train a wav2vec model:


### PR DESCRIPTION
## 📚 typo in wav2vec example README.md

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests? 

## What does this PR do?
Fixes(#2313)

I find a Documentation typo in `fairseq/examples/wav2vec/README.md` 

the **Prepare training data manifest** command script has an error.

the error command script in [line 35](https://github.com/pytorch/fairseq/blame/master/examples/wav2vec/README.md#L33) is
```
$ python scripts/wav2vec_manifest.py /path/to/waves --dest /manifest/path --ext wav
```

which is different from the command in [line 89](https://github.com/pytorch/fairseq/blame/master/examples/wav2vec/README.md#L89), and `fairseq/scripts/wav2vec_manifest.py` does not exist, so I think the right command should be

```
$ python examples/wav2vec/wav2vec_manifest.py /path/to/waves --dest /manifest/path --ext wav
```


