### PR TITLE
made --sentencepiece-vocab flag more clear

### DIFF
--- a/fairseq/data/encoders/sentencepiece_bpe.py
+++ b/fairseq/data/encoders/sentencepiece_bpe.py
@@ -14,15 +14,15 @@ class SentencepieceBPE(object):
     def add_args(parser):
         # fmt: off
         parser.add_argument('--sentencepiece-vocab', type=str,
-                            help='path to sentencepiece vocab')
+                            help='path to sentencepiece model (not vocab, flag name is incorrect)')
         # fmt: on
 
     def __init__(self, args):
-        vocab = file_utils.cached_path(args.sentencepiece_vocab)
+        sentencepiece_model = file_utils.cached_path(args.sentencepiece_vocab)
         try:
             import sentencepiece as spm
             self.sp = spm.SentencePieceProcessor()
-            self.sp.Load(vocab)
+            self.sp.Load(sentencepiece_model)
         except ImportError:
             raise ImportError('Please install sentencepiece with: pip install sentencepiece')
 


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (doc change, so not necessary)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  n/a

## What does this PR do?
Addresses #2319 by making it clear that the --sentencepiece-vocab requires a path to a sentencepiece model.