### PR TITLE
optional limit on total training time

### DIFF
--- a/fairseq/options.py
+++ b/fairseq/options.py
@@ -443,6 +443,8 @@ def add_optimization_args(parser):
                        help='force stop training at specified epoch')
     group.add_argument('--max-update', '--mu', default=0, type=int, metavar='N',
                        help='force stop training at specified update')
+    group.add_argument('--stop-time-hr', default=0, type=float, metavar='N',
+                       help='force stop training after specified cumulative time (if >0)')
     group.add_argument('--clip-norm', default=0.0, type=float, metavar='NORM',
                        help='clip threshold of gradients')
     group.add_argument('--sentence-avg', action='store_true',

--- a/fairseq_cli/train.py
+++ b/fairseq_cli/train.py
@@ -243,6 +243,12 @@ def train(args, trainer, task, epoch_itr):
         valid_losses, should_stop = validate_and_save(
             args, trainer, task, epoch_itr, valid_subsets, end_of_epoch
         )
+
+        if args.stop_time_hr > 0:
+            elapsed_hr = trainer.cumulative_training_time() / (60 * 60)
+            if elapsed_hr > args.stop_time_hr:
+                should_stop = True
+
         if should_stop:
             break
 


### PR DESCRIPTION
Summary:
This change adds a new option (`--stop-time-hr`) which if specified limits the total training time to that number of hours. In order to stop training within the inner training loop (after the first update exceeding the time limit) the starting time is stored on the trainer.

In addition, in order to persist the training time when when restoring from checkpoints (important because training runs are sometimes killed due to resource constraints), training time already completed is stored as extra state in the checkpoints (though this change is backward compatible with existing checkpoints).

Differential Revision: D22573166

