### PR TITLE
Fix fairseq-generate score printing (fixes #2355)

### DIFF
--- a/fairseq/bleu.py
+++ b/fairseq/bleu.py
@@ -55,7 +55,7 @@ class SacrebleuScorer(object):
     def result_string(self, order=4):
         if order != 4:
             raise NotImplementedError
-        return self.sacrebleu.corpus_bleu(self.sys, [self.ref])
+        return self.sacrebleu.corpus_bleu(self.sys, [self.ref]).format()
 
 
 class Scorer(object):


### PR DESCRIPTION
I think .format() should be added to the return line as the latest sacrebleu.corpus_bleu() now returns an object not a string
