### PR TITLE
Enable already_numberized dataset for preprocess

### DIFF
--- a/fairseq/options.py
+++ b/fairseq/options.py
@@ -330,6 +330,8 @@ def add_preprocess_args(parser):
                        help="Pad dictionary size to be multiple of N")
     group.add_argument("--workers", metavar="N", default=1, type=int,
                        help="number of parallel workers")
+    group.add_argument('--already-numberized', default=False, action='store_true',
+                       help='already-numberized dataset')
     # fmt: on
     return parser
 

--- a/fairseq_cli/preprocess.py
+++ b/fairseq_cli/preprocess.py
@@ -107,10 +107,11 @@ def main(args):
     if target and tgt_dict is not None:
         tgt_dict.save(dict_path(args.target_lang))
 
-    def make_binary_dataset(vocab, input_prefix, output_prefix, lang, num_workers):
+    def make_binary_dataset(vocab, input_prefix, output_prefix, lang, num_workers, already_numberized=False):
         logger.info("[{}] Dictionary: {} types".format(lang, len(vocab)))
         n_seq_tok = [0, 0]
         replaced = Counter()
+        append_eos = not already_numberized
 
         def merge_result(worker_result):
             replaced.update(worker_result["replaced"])
@@ -135,7 +136,9 @@ def main(args):
                         prefix,
                         lang,
                         offsets[worker_id],
-                        offsets[worker_id + 1]
+                        offsets[worker_id + 1],
+                        append_eos,
+                        already_numberized,
                     ),
                     callback=merge_result
                 )
@@ -146,7 +149,7 @@ def main(args):
         merge_result(
             Binarizer.binarize(
                 input_file, vocab, lambda t: ds.add_item(t),
-                offset=0, end=offsets[1]
+                offset=0, end=offsets[1], append_eos=append_eos, already_numberized=already_numberized
             )
         )
         if num_workers > 1:
@@ -225,7 +228,7 @@ def main(args):
             )
         )
 
-    def make_dataset(vocab, input_prefix, output_prefix, lang, num_workers=1):
+    def make_dataset(vocab, input_prefix, output_prefix, lang, num_workers=1, already_numberized=False):
         if args.dataset_impl == "raw":
             # Copy original text file to destination folder
             output_text_file = dest_path(
@@ -234,19 +237,19 @@ def main(args):
             )
             shutil.copyfile(file_name(input_prefix, lang), output_text_file)
         else:
-            make_binary_dataset(vocab, input_prefix, output_prefix, lang, num_workers)
+            make_binary_dataset(vocab, input_prefix, output_prefix, lang, num_workers, already_numberized=already_numberized)
 
     def make_all(lang, vocab):
         if args.trainpref:
-            make_dataset(vocab, args.trainpref, "train", lang, num_workers=args.workers)
+            make_dataset(vocab, args.trainpref, "train", lang, num_workers=args.workers, already_numberized=args.already_numberized)
         if args.validpref:
             for k, validpref in enumerate(args.validpref.split(",")):
                 outprefix = "valid{}".format(k) if k > 0 else "valid"
-                make_dataset(vocab, validpref, outprefix, lang, num_workers=args.workers)
+                make_dataset(vocab, validpref, outprefix, lang, num_workers=args.workers, already_numberized=args.already_numberized)
         if args.testpref:
             for k, testpref in enumerate(args.testpref.split(",")):
                 outprefix = "test{}".format(k) if k > 0 else "test"
-                make_dataset(vocab, testpref, outprefix, lang, num_workers=args.workers)
+                make_dataset(vocab, testpref, outprefix, lang, num_workers=args.workers, already_numberized=args.already_numberized)
 
     def make_all_alignments():
         if args.trainpref and os.path.exists(args.trainpref + "." + args.align_suffix):
@@ -307,7 +310,7 @@ def main(args):
                 print("{} {}".format(src_dict[k], tgt_dict[v]), file=f)
 
 
-def binarize(args, filename, vocab, output_prefix, lang, offset, end, append_eos=True):
+def binarize(args, filename, vocab, output_prefix, lang, offset, end, append_eos=True, already_numberized=False):
     ds = indexed_dataset.make_builder(dataset_dest_file(args, output_prefix, lang, "bin"),
                                       impl=args.dataset_impl, vocab_size=len(vocab))
 
@@ -315,7 +318,7 @@ def binarize(args, filename, vocab, output_prefix, lang, offset, end, append_eos
         ds.add_item(tensor)
 
     res = Binarizer.binarize(filename, vocab, consumer, append_eos=append_eos,
-                             offset=offset, end=end)
+                             offset=offset, end=end, already_numberized=already_numberized)
     ds.finalize(dataset_dest_file(args, output_prefix, lang, "idx"))
     return res
 
@@ -335,13 +338,12 @@ def binarize_alignments(args, filename, parse_alignment, output_prefix, offset, 
 
 def dataset_dest_prefix(args, output_prefix, lang):
     base = "{}/{}".format(args.destdir, output_prefix)
-    if lang is not None:
+    if args.only_source:
+        lang_part = ".{}".format(lang) if lang is not None else ""
+    elif lang is not None:
         lang_part = ".{}-{}.{}".format(args.source_lang, args.target_lang, lang)
-    elif args.only_source:
-        lang_part = ""
     else:
         lang_part = ".{}-{}".format(args.source_lang, args.target_lang)
-
     return "{}{}".format(base, lang_part)
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -127,7 +127,7 @@ def sequence_generator_setup():
     return tgt_dict, w1, w2, src_tokens, src_lengths, model
 
 
-def create_dummy_data(data_dir, num_examples=100, maxlen=20, alignment=False):
+def create_dummy_data(data_dir, num_examples=100, maxlen=20, alignment=False, numberized=False):
     def _create_dummy_data(filename):
         data = torch.rand(num_examples * maxlen)
         data = 97 + torch.floor(26 * data).int()
@@ -153,6 +153,16 @@ def create_dummy_data(data_dir, num_examples=100, maxlen=20, alignment=False):
                 ex_str = ' '.join(["{}-{}".format(src, tgt) for src, tgt in zip(src_indices, tgt_indices)])
                 print(ex_str, file=h)
 
+    def _create_dummy_numberized_data(filename):
+        data = [str(random.randint(0, 100)) for i in range(num_examples * maxlen)]
+        with open(os.path.join(data_dir, filename), 'w') as h:
+            offset = 0
+            for _ in range(num_examples):
+                ex_len = random.randint(1, maxlen)
+                ex_str = ' '.join(data[offset:offset+ex_len])
+                print(ex_str, file=h)
+                offset += ex_len
+
     _create_dummy_data('train.in')
     _create_dummy_data('train.out')
     _create_dummy_data('valid.in')
@@ -164,6 +174,14 @@ def create_dummy_data(data_dir, num_examples=100, maxlen=20, alignment=False):
         _create_dummy_alignment_data('train.in', 'train.out', 'train.align')
         _create_dummy_alignment_data('valid.in', 'valid.out', 'valid.align')
         _create_dummy_alignment_data('test.in', 'test.out', 'test.align')
+
+    if numberized:
+        _create_dummy_numberized_data('train.in')
+        _create_dummy_numberized_data('train.out')
+        _create_dummy_numberized_data('valid.in')
+        _create_dummy_numberized_data('valid.out')
+        _create_dummy_numberized_data('test.in')
+        _create_dummy_numberized_data('test.out')
 
 
 def preprocess_lm_data(data_dir):
@@ -192,6 +210,19 @@ def preprocess_translation_data(data_dir, extra_flags=None):
             '--destdir', data_dir,
         ] + (extra_flags or []),
     )
+    preprocess.main(preprocess_args)
+
+
+def preprocess_numberized_lm_data(data_dir):
+    preprocess_parser = options.get_preprocessing_parser()
+    preprocess_args = preprocess_parser.parse_args([
+        '--only-source',
+        '--already-numberized',
+        '--trainpref', os.path.join(data_dir, 'train.out'),
+        '--validpref', os.path.join(data_dir, 'valid.out'),
+        '--testpref', os.path.join(data_dir, 'test.out'),
+        '--destdir', data_dir,
+    ])
     preprocess.main(preprocess_args)
 
 


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  

## What does this PR do?

### 1. Enable `already_numberized` dataset for preprocess

This feature enable binarization for any `already_numberized` dataset.

### 2. Enable named binary file for  only-source dataset

Before this commit:  `fairseq-preprocess --only-source ...` will export training data as `train.bin` and `train.idx`

After this commit:  `fairseq-preprocess --only-source --source-lang en ...` will export training data as `train.en.bin` and `train.en.idx`, which is more flexible and clear.

## Related src code

Release `already_numberized` parameter to `fairseq-preprocess`.

https://github.com/pytorch/fairseq/blob/8449c5f4e85d7658e533ffae3dac716d04cb2f0e/fairseq/binarizer.py#L24-L36


## Did you have fun?
Make sure you had fun coding 🙃
