### PR TITLE
Small fix for load_indexed_dataset parameter

### DIFF
--- a/fairseq/data/data_utils.py
+++ b/fairseq/data/data_utils.py
@@ -54,7 +54,7 @@ def collate_tokens(values, pad_idx, eos_idx=None, left_pad=False, move_eos_to_be
     return res
 
 
-def load_indexed_dataset(path, dictionary, dataset_impl=None, combine=False, default='cached'):
+def load_indexed_dataset(path, dictionary=None, dataset_impl=None, combine=False, default='cached'):
     """A helper function for loading indexed datasets.
 
     Args:


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  

## What does this PR do?

`dictionary` is not a required parameter for `load_indexed_dataset`.


## Did you have fun?
Make sure you had fun coding 🙃
