### PR TITLE
also call model.all_reduce() in valid_step() when using LegacyDistrib…

### DIFF
--- a/fairseq/trainer.py
+++ b/fairseq/trainer.py
@@ -643,6 +643,9 @@ class Trainer(object):
                 logging_outputs, sample_size, ignore=is_dummy_batch,
             )
 
+        if hasattr(self.model, 'all_reduce'):
+            self.model.all_reduce()
+
         # log validation stats
         logging_output = self._reduce_and_log_stats(logging_outputs, sample_size)
 


### PR DESCRIPTION
…utedDataParallel. Otherwise there will be a RuntimeError at [this line](https://github.com/pytorch/fairseq/blob/master/fairseq/legacy_distributed_data_parallel.py#L91) while doing validation with LegacyDDP.

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  

## What does this PR do?
Fixes # (issue).

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
