### PR TITLE
collate more input datas into batches

### DIFF
--- a/fairseq/data/language_pair_dataset.py
+++ b/fairseq/data/language_pair_dataset.py
@@ -22,6 +22,7 @@ def collate(
     left_pad_target=False,
     input_feeding=True,
     pad_to_length=None,
+    more_input_keys=[],
 ):
     if len(samples) == 0:
         return {}
@@ -107,6 +108,10 @@ def collate(
     }
     if prev_output_tokens is not None:
         batch['net_input']['prev_output_tokens'] = prev_output_tokens.index_select(0, sort_order)
+
+    # collate more input datas into batches
+    for key in more_input_keys:
+        batch['net_input'][key] = merge(key, left_pad=False).index_select(0, sort_order)
 
     if samples[0].get('alignment', None) is not None:
         bsz, tgt_sz = batch['target'].shape


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  

## What does this PR do?

It collate/pack more input datas into batches besides 'source' and 'target'.

Generalized function is more favorable to fit various collater. e.g. pack `src_lang_id` into batches
https://github.com/pytorch/fairseq/blob/488254c88030d4e1fbfb85dbb8a90c97256bf491/fairseq/data/multilingual/sampled_multi_dataset.py#L285-L286

## Did you have fun?
Make sure you had fun coding 🙃
