### PR TITLE
Stricter boundary checks for iterator sizes

### DIFF
--- a/fairseq/data/iterators.py
+++ b/fairseq/data/iterators.py
@@ -296,9 +296,16 @@ class EpochBatchIterator(EpochBatchIterating):
 
     def state_dict(self):
         """Returns a dictionary containing a whole state of the iterator."""
+        if self.end_of_epoch():
+            epoch = self.epoch + 1
+            iter_in_epoch = 0
+        else:
+            epoch = self.epoch
+            iter_in_epoch = self.iterations_in_epoch
         return {
-            'epoch': self.epoch,
-            'iterations_in_epoch': self.iterations_in_epoch,
+            'version': 2,
+            'epoch': epoch,
+            'iterations_in_epoch': iter_in_epoch,
             'shuffle': self.shuffle,
         }
 
@@ -306,6 +313,7 @@ class EpochBatchIterator(EpochBatchIterating):
         """Copies the state of the iterator from the given *state_dict*."""
         self.epoch = state_dict['epoch']
         itr_pos = state_dict.get('iterations_in_epoch', 0)
+        version = state_dict.get('version', 1)
         if itr_pos > 0:
             # fast-forward epoch iterator
             self._next_epoch_itr = self._get_iterator_for_epoch(
@@ -314,8 +322,15 @@ class EpochBatchIterator(EpochBatchIterating):
                 offset=itr_pos,
             )
             if self._next_epoch_itr is None:
-                # we finished the epoch, increment epoch counter
-                self.epoch += 1
+                if version == 1:
+                    # legacy behavior: we finished the epoch, increment epoch counter
+                    self.epoch += 1
+                else:
+                    raise RuntimeError(
+                        'Cannot resume training due to dataloader mismatch, please '
+                        'report this to the fairseq developers. You can relaunch '
+                        'training with `--reset-dataloader` and it should work.'
+                    )
         else:
             self._next_epoch_itr = None
 

--- a/fairseq/tasks/fairseq_task.py
+++ b/fairseq/tasks/fairseq_task.py
@@ -157,7 +157,7 @@ class FairseqTask(object):
         num_shards=1,
         shard_id=0,
         num_workers=0,
-        epoch=1
+        epoch=1,
     ):
         """
         Get an iterator that yields batches of data from the given dataset.
@@ -228,7 +228,7 @@ class FairseqTask(object):
             shard_id=shard_id,
             num_workers=num_workers,
             epoch=epoch,
-            buffer_size=getattr(self.args, 'data_buffer_size', 0)
+            buffer_size=getattr(self.args, 'data_buffer_size', 0),
         )
         self.dataset_to_epoch_iter[dataset] = epoch_iter
         return epoch_iter

--- a/fairseq/trainer.py
+++ b/fairseq/trainer.py
@@ -347,7 +347,7 @@ class Trainer(object):
             num_shards=self.data_parallel_world_size if shard_batch_itr else 1,
             shard_id=self.data_parallel_rank if shard_batch_itr else 0,
             num_workers=self.args.num_workers,
-            epoch=epoch
+            epoch=epoch,
         )
 
     def get_valid_iterator(
@@ -368,7 +368,7 @@ class Trainer(object):
             seed=self.args.seed,
             num_shards=self.data_parallel_world_size,
             shard_id=self.data_parallel_rank,
-            num_workers=self.args.num_workers
+            num_workers=self.args.num_workers,
         )
 
     def begin_epoch(self, epoch):


### PR DESCRIPTION
There have been issues with some dynamic datasets where the iteration count stored in the checkpoint overflows the actual iterator size, but we've been unable to reproduce it in any reliable way. This overflow can apparently cause the epoch to advance when loading checkpoints, which is undesirable.

This PR changes two things. First at the end of an epoch we advance the iterator to the next epoch directly in `state_dict`, so that we can distinguish this overflow corner case and the more typical end-of-epoch situation. We then raise an exception in the case of iterator overflow, which will hopefully help us (via the community) find a more reliable repro for the underlying issue.