### PR TITLE
[WIP] fairseq.types

### DIFF
--- a/fairseq/types.py
+++ b/fairseq/types.py
@@ -1,0 +1,21 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Utility file containing some commonly used data types in fairseq."""
+
+from typing import Dict, List, NamedTuple, Optional, Tuple
+
+from torch import Tensor
+
+IncrementalState = Dict[str, Dict[str, Optional[Tensor]]]
+IncrementalBuffer = Dict[str, Optional[Tensor]]
+
+class EncoderOut(NamedTuple):
+    encoder_out: Tensor
+    encoder_padding_mask: Optional[Tensor] = None
+    encoder_embedding: Optional[Tensor] = None
+    encoder_states: Optional[List[Tensor]] = None
+    src_tokens: Optional[Tensor] = None
+    src_lengths: Optional[Tensor] = None


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?

Suggest `fairseq.types` as a way to easily access some commonly used data types such as those involving
incremental states and transformer encoder.

## Motivation

It's very tedious to have to copy and paste `Dict[str, Dict[str, Optional[Tensor]]]` over and over and some commonly used data types like `EncoderOut` are located in not so convenient locations.
Sometimes, we just wanted to import the type for type hints but as things stand, it's a little inconvenient.

Commonly used types can be stored in `fairseq.types` as an easy way for developers to access various `fairseq` related datatypes.

If it's not immediately obvious, this PR is WIP. Let me know if I should continue.