### PR TITLE
Update transformer_layer.py

### DIFF
--- a/fairseq/modules/transformer_layer.py
+++ b/fairseq/modules/transformer_layer.py
@@ -324,7 +324,7 @@ class TransformerDecoderLayer(nn.Module):
         if not self.normalize_before:
             x = self.self_attn_layer_norm(x)
 
-        if self.encoder_attn is not None:
+        if self.encoder_attn is not None and encoder_out is not None:
             residual = x
             if self.normalize_before:
                 x = self.encoder_attn_layer_norm(x)


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  

## What does this PR do?

In some cases, we want to use the decoder-only model from a pretrained transformer (`encoder_attn` is not None).

This commit is minor but important, which not only makes `TransformerDecoderLayer` more robust but also make it compitible with decoder-only model from pretrained transformer.

If you want to use decoder from pretrained transformer, you can just set `encoder_out` as None.





## Did you have fun?
Make sure you had fun coding 🙃
