### PR TITLE
Changed EnvironmentError to RuntimeError in get_from_cache

### DIFF
--- a/fairseq/file_utils.py
+++ b/fairseq/file_utils.py
@@ -264,7 +264,7 @@ def get_from_cache(url, cache_dir=None):
                 etag = None
             else:
                 etag = response.headers.get("ETag")
-        except EnvironmentError:
+        except RuntimeError:
             etag = None
 
     filename = url_to_filename(url, etag)


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?   
No need I believe
- [x] Did you write any new necessary tests?  
No
## What does this PR do?
Fixes https://github.com/pytorch/fairseq/issues/2724

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Yes! It is not a big PR at all but it allowed me to familiarize with the caching/downloading logic used in fairseq (which is very similar to that used in pytorch/transformers)
