### PR TITLE
Centralize hydra init (and support packaged location of configs)

### DIFF
--- a/fairseq/__init__.py
+++ b/fairseq/__init__.py
@@ -23,6 +23,10 @@ sys.modules["fairseq.meters"] = meters
 sys.modules["fairseq.metrics"] = metrics
 sys.modules["fairseq.progress_bar"] = progress_bar
 
+# initialize hydra
+from fairseq.dataclass.initialize import hydra_init
+hydra_init()
+
 import fairseq.criterions  # noqa
 import fairseq.models  # noqa
 import fairseq.modules  # noqa

--- a/fairseq/dataclass/initialize.py
+++ b/fairseq/dataclass/initialize.py
@@ -4,10 +4,13 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
+import os
 
 from typing import Dict, Any
 
 from hydra.core.config_store import ConfigStore
+from hydra.core.global_hydra import GlobalHydra
+from hydra.experimental import initialize
 
 from fairseq.dataclass.configs import FairseqConfig
 
@@ -17,6 +20,20 @@ from fairseq.registry import REGISTRIES
 
 
 logger = logging.getLogger(__name__)
+
+
+def hydra_init():
+    cs = ConfigStore.instance()
+    register_hydra_cfg(cs)
+
+    if not GlobalHydra().is_initialized():
+        # configs will be in fairseq/config after installation
+        config_path = os.path.join("..", "config")
+        if not os.path.exists(config_path):
+            # in case of "--editable" installs we need to go one dir up
+            config_path = os.path.join("..", "..", "config")
+
+        initialize(config_path=config_path, strict=True)
 
 
 def register_module_dataclass(

--- a/fairseq/dataclass/utils.py
+++ b/fairseq/dataclass/utils.py
@@ -277,11 +277,6 @@ def convert_namespace_to_omegaconf(args: Namespace) -> DictConfig:
     overrides, deletes = override_module_args(args)
 
     cfg_name = "config"
-    cfg_path = f"../../{cfg_name}"
-
-    if not GlobalHydra().is_initialized():
-        initialize(config_path=cfg_path)
-
     composed_cfg = compose(cfg_name, overrides=overrides, strict=False)
     for k in deletes:
         composed_cfg[k] = None

--- a/fairseq_cli/eval_lm.py
+++ b/fairseq_cli/eval_lm.py
@@ -16,13 +16,10 @@ from argparse import Namespace
 import torch
 from fairseq import checkpoint_utils, distributed_utils, options, tasks, utils
 from fairseq.data import LMContextWindowDataset
-from fairseq.dataclass.initialize import register_hydra_cfg
 from fairseq.dataclass.utils import convert_namespace_to_omegaconf
 from fairseq.logging import progress_bar
 from fairseq.logging.meters import StopwatchMeter, TimeMeter
 from fairseq.sequence_scorer import SequenceScorer
-from hydra.core.config_store import ConfigStore
-from hydra.experimental import initialize
 from omegaconf import DictConfig
 
 
@@ -288,7 +285,4 @@ def cli_main():
 
 
 if __name__ == "__main__":
-    cs = ConfigStore.instance()
-    register_hydra_cfg(cs)
-    initialize(config_path="../config", strict=True)
     cli_main()

--- a/fairseq_cli/generate.py
+++ b/fairseq_cli/generate.py
@@ -19,12 +19,9 @@ import numpy as np
 import torch
 from fairseq import checkpoint_utils, options, scoring, tasks, utils
 from fairseq.data import encoders
-from fairseq.dataclass.initialize import register_hydra_cfg
 from fairseq.dataclass.utils import convert_namespace_to_omegaconf
 from fairseq.logging import progress_bar
 from fairseq.logging.meters import StopwatchMeter, TimeMeter
-from hydra.core.config_store import ConfigStore
-from hydra.experimental import initialize
 from omegaconf import DictConfig
 
 
@@ -393,7 +390,4 @@ def cli_main():
 
 
 if __name__ == "__main__":
-    cs = ConfigStore.instance()
-    register_hydra_cfg(cs)
-    initialize(config_path="../config", strict=True)
     cli_main()

--- a/fairseq_cli/interactive.py
+++ b/fairseq_cli/interactive.py
@@ -22,12 +22,9 @@ import torch
 from fairseq import checkpoint_utils, distributed_utils, options, tasks, utils
 from fairseq.data import encoders
 from fairseq.dataclass.configs import FairseqConfig
-from fairseq.dataclass.initialize import register_hydra_cfg
 from fairseq.dataclass.utils import convert_namespace_to_omegaconf
 from fairseq.token_generation_constraints import pack_constraints, unpack_constraints
 from fairseq_cli.generate import get_symbols_to_strip_from_output
-from hydra.core.config_store import ConfigStore
-from hydra.experimental import initialize
 
 
 logging.basicConfig(
@@ -322,7 +319,4 @@ def cli_main():
 
 
 if __name__ == "__main__":
-    cs = ConfigStore.instance()
-    register_hydra_cfg(cs)
-    initialize(config_path="../config", strict=True)
     cli_main()

--- a/fairseq_cli/train.py
+++ b/fairseq_cli/train.py
@@ -16,7 +16,6 @@ from typing import Dict, Optional, Any, List, Tuple, Callable
 
 import numpy as np
 import torch
-from hydra.core.config_store import ConfigStore
 
 from fairseq import (
     checkpoint_utils,
@@ -31,8 +30,6 @@ from fairseq.dataclass.utils import convert_namespace_to_omegaconf
 from fairseq.logging import meters, metrics, progress_bar
 from fairseq.model_parallel.megatron_trainer import MegatronTrainer
 from omegaconf import DictConfig
-from hydra.experimental import initialize
-from fairseq.dataclass.initialize import register_hydra_cfg
 from fairseq.trainer import Trainer
 
 
@@ -353,7 +350,4 @@ def cli_main(modify_parser: Optional[Callable[[argparse.ArgumentParser], None]] 
 
 
 if __name__ == '__main__':
-    cs = ConfigStore.instance()
-    register_hydra_cfg(cs)
-    initialize(config_path="../config", strict=True)
     cli_main()

--- a/fairseq_cli/validate.py
+++ b/fairseq_cli/validate.py
@@ -13,11 +13,8 @@ from itertools import chain
 
 import torch
 from fairseq import checkpoint_utils, distributed_utils, options, utils
-from fairseq.dataclass.initialize import register_hydra_cfg
 from fairseq.dataclass.utils import convert_namespace_to_omegaconf
 from fairseq.logging import metrics, progress_bar
-from hydra.core.config_store import ConfigStore
-from hydra.experimental import initialize
 from omegaconf import DictConfig
 
 
@@ -140,7 +137,4 @@ def cli_main():
 
 
 if __name__ == "__main__":
-    cs = ConfigStore.instance()
-    register_hydra_cfg(cs)
-    initialize(config_path="../config", strict=True)
     cli_main()


### PR DESCRIPTION
Configs can either be in `/fairseq/configs` (once the package is installed) or `/configs` (if using an editable installation). This centralizes the hydra init and supports these two possible config locations.