### PR TITLE
deprecation warning fixes

### DIFF
--- a/fairseq/optim/adam.py
+++ b/fairseq/optim/adam.py
@@ -95,7 +95,7 @@ class FairseqAdam(FairseqOptimizer):
 
 
 class Adam(torch.optim.Optimizer):
-    """Implements Adam algorithm.
+    r"""Implements Adam algorithm.
 
     This implementation is modified from torch.optim.Adam based on:
     `Fixed Weight Decay Regularization in Adam`

--- a/fairseq/optim/adam.py
+++ b/fairseq/optim/adam.py
@@ -5,7 +5,7 @@
 
 import logging
 import math
-from collections import Collection
+from collections.abc import Collection
 from dataclasses import dataclass, field
 from typing import List
 

--- a/fairseq/optim/nag.py
+++ b/fairseq/optim/nag.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from collections import Collection
+from collections.abc import Collection
 from dataclasses import dataclass, field
 from typing import List
 


### PR DESCRIPTION
## What does this PR do?

Fixes:

- 2x `DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working`

- 1x `/fairseq/optim/adam.py:98: DeprecationWarning: invalid escape sequence \:`

This is with py38.
