### PR TITLE
Fixed min-lr / max-lr swap on cosine schedule.

### DIFF
--- a/fairseq/optim/lr_scheduler/cosine_lr_scheduler.py
+++ b/fairseq/optim/lr_scheduler/cosine_lr_scheduler.py
@@ -86,8 +86,10 @@ class CosineSchedule(FairseqLRScheduler):
         if cfg.warmup_init_lr < 0:
             cfg.warmup_init_lr = lr
 
-        self.min_lr = lr
-        self.max_lr = cfg.max_lr
+        # default min_lr=-1 -> cosine anneale to lr=0.0
+        # otherwise pick min_lr from config
+        self.min_lr = cfg.min_lr if cfg.min_lr > 0.0 else 0.0
+        self.max_lr = lr
         assert self.max_lr > self.min_lr, "max_lr must be more than lr"
 
         self.t_mult = cfg.t_mult


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?
The cosine learning rate scheduler was implemented incorrectly. It annealed to the learning rate (`--lr`) instead of the minimum learning rate (`--min-lr`). This implementation is consistent with the PyTorch [CosineAnnealingLR](https://github.com/pytorch/pytorch/blob/master/torch/optim/lr_scheduler.py#L461).

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
