### PR TITLE
Added `min_lr` to CosineLRScheduleConfig

### DIFF
--- a/fairseq/optim/lr_scheduler/cosine_lr_scheduler.py
+++ b/fairseq/optim/lr_scheduler/cosine_lr_scheduler.py
@@ -29,6 +29,9 @@ class CosineLRScheduleConfig(FairseqDataclass):
     max_lr: float = field(
         default=1.0, metadata={"help": "max learning rate, must be more than cfg.lr"}
     )
+    min_lr: float = field(
+        default=0.0, metadata={"help": "min learning rate, must be less than cfg.lr"}
+    )
     t_mult: float = field(
         default=1.0, metadata={"help": "factor to grow the length of each period"}
     )


### PR DESCRIPTION
There was no min_lr argument in the config (causing "not found" style errors), so I've added it.

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?
Fixes the lack of a `min_lr` argument (resulting in errors) in the new hydra config for the CosineLRScheduler.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
