### PR TITLE
update sequence generator device change

### DIFF
--- a/fairseq/sequence_generator.py
+++ b/fairseq/sequence_generator.py
@@ -278,8 +278,8 @@ class SequenceGenerator(nn.Module):
         cand_size = 2 * beam_size  # 2 x beam size in case half are EOS
 
         # offset arrays for converting between different indexing schemes
-        bbsz_offsets = (torch.arange(0, bsz) * beam_size).unsqueeze(1).type_as(tokens)
-        cand_offsets = torch.arange(0, cand_size).type_as(tokens)
+        bbsz_offsets = (torch.arange(0, bsz) * beam_size).unsqueeze(1).type_as(tokens).to(src_tokens.device)
+        cand_offsets = torch.arange(0, cand_size).type_as(tokens).to(src_tokens.device)
 
         reorder_state: Optional[Tensor] = None
         batch_idxs: Optional[Tensor] = None


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?
Fixes Sequence Generator

Reproduce the bug:
1. Background: 
**fairseq.utils.move_to_cuda** function support to change device.
2. When you change the file **fairseq_cli/generate.py**
suppose `gpu_id = 1`
- line 134 change from
`model.cuda()`
to
`model.cuda(gpu_id)`
- line 189 change from
`sample = utils.move_to_cuda(sample) if use_cuda else sample` 
to 
`sample = utils.move_to_cuda(sample, gpu_id) if use_cuda else sample`
2. you will get an error
```
fairseq/sequence_generator.py, line 382, in generate
    cand_bbsz_idx = cand_beams.add(bbsz_offsets)
RuntimeError: binary_op(): expected both inputs to be on same device, but input a is on cuda:1 and input b is on cuda:0

```

The reason of this bug is that `bbsz_offsets` is not assigned to proper cuda device. Therefore, we need to change the line 281 and line 281 of the file **fairseq/sequence_generator.py** 

The test file for this fix is the file **tests/test_sequence_generator.py**

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃 
very happy 🙂