### PR TITLE
Fix #3017: restore support for user modules in zip/jar files

### DIFF
--- a/fairseq/utils.py
+++ b/fairseq/utils.py
@@ -437,7 +437,7 @@ def import_user_module(args):
     module_path = getattr(args, "user_dir", None)
     if module_path is not None:
         module_path = os.path.abspath(args.user_dir)
-        if not os.path.exists(module_path):
+        if not os.path.exists(module_path) and not os.path.isfile(os.path.dirname(module_path)):
             fairseq_rel_path = os.path.join(os.path.dirname(__file__), args.user_dir)
             if os.path.exists(fairseq_rel_path):
                 module_path = fairseq_rel_path


### PR DESCRIPTION
## What does this PR do?
Fixes #3017 

My original implementation of the function utils.import_user_module supported external user modules wrapped in zip/jar files (python natively support modules in zip/jar files).

The new piece of code which checks for file existence breaks this functionality.
This trivial fix can solve the problem!