### PR TITLE
Fix parameter

### DIFF
--- a/fairseq/models/transformer.py
+++ b/fairseq/models/transformer.py
@@ -402,7 +402,7 @@ class TransformerEncoder(FairseqEncoder):
     def forward(
         self,
         src_tokens,
-        src_lengths,
+        src_lengths: Optional[torch.Tensor] = None,
         return_all_hiddens: bool = False,
         token_embeddings: Optional[torch.Tensor] = None,
     ):
@@ -418,7 +418,7 @@ class TransformerEncoder(FairseqEncoder):
                 default `None` will recompute embeddings
 
         Returns:
-            namedtuple:
+            dict:
                 - **encoder_out** (Tensor): the last encoder layer's output of
                   shape `(src_len, batch, embed_dim)`
                 - **encoder_padding_mask** (ByteTensor): the positions of


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  

## What does this PR do?

`src_lengths` is not a required parameter in `TransformerEncoder`.
It is a dummy variable. 

Maybe more changes should be done to fix this issue in Class such as `Transformer`, `FairseqEncoderDecoderModel`, `BARTModel` etc.


## Did you have fun?
Make sure you had fun coding 🙃
