### PR TITLE
Reorganize self.emb_layer_norm

### DIFF
--- a/fairseq/modules/transformer_sentence_encoder.py
+++ b/fairseq/modules/transformer_sentence_encoder.py
@@ -145,6 +145,11 @@ class TransformerSentenceEncoder(nn.Module):
             else None
         )
 
+        if encoder_normalize_before:
+            self.emb_layer_norm = LayerNorm(self.embedding_dim, export=export)
+        else:
+            self.emb_layer_norm = None
+
         if self.layerdrop > 0.0:
             self.layers = LayerDropModuleList(p=self.layerdrop)
         else:
@@ -166,11 +171,6 @@ class TransformerSentenceEncoder(nn.Module):
                 for _ in range(num_encoder_layers)
             ]
         )
-
-        if encoder_normalize_before:
-            self.emb_layer_norm = LayerNorm(self.embedding_dim, export=export)
-        else:
-            self.emb_layer_norm = None
 
         # Apply initialization of model params after building the model
         if self.apply_bert_init:


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  

## What does this PR do?

Reorganize `self.emb_layer_norm` in order to keep right order while `print(model)` 

## Did you have fun?
Make sure you had fun coding 🙃
