### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/fairseq/optim/adafactor.py
+++ b/fairseq/optim/adafactor.py
@@ -76,7 +76,7 @@ class Adafactor(torch.optim.Optimizer):
     schedule you should set `scale_parameter=False` and
     `relative_step=False`.
 
-    Arguments:
+    Args:
         params (iterable): iterable of parameters to optimize or dicts defining
             parameter groups
         lr (float, optional): external learning rate (default: None)
@@ -168,7 +168,7 @@ class Adafactor(torch.optim.Optimizer):
     def step(self, closure=None):
         """Performs a single optimization step.
 
-        Arguments:
+        Args:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """

--- a/fairseq/optim/adam.py
+++ b/fairseq/optim/adam.py
@@ -103,7 +103,7 @@ class Adam(torch.optim.Optimizer):
 
     It has been proposed in `Adam: A Method for Stochastic Optimization`_.
 
-    Arguments:
+    Args:
         params (iterable): iterable of parameters to optimize or dicts defining
             parameter groups
         lr (float, optional): learning rate (default: 1e-3)
@@ -146,7 +146,7 @@ class Adam(torch.optim.Optimizer):
     def step(self, closure=None):
         """Performs a single optimization step.
 
-        Arguments:
+        Args:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """

--- a/fairseq/optim/adamax.py
+++ b/fairseq/optim/adamax.py
@@ -53,7 +53,7 @@ class Adamax(torch.optim.Optimizer):
 
     Compared to the version in PyTorch, this version implements a fix for weight decay.
 
-    Arguments:
+    Args:
         params (iterable): iterable of parameters to optimize or dicts defining
             parameter groups
         lr (float, optional): learning rate (default: 2e-3)
@@ -107,7 +107,7 @@ class Adamax(torch.optim.Optimizer):
     def step(self, closure=None):
         """Performs a single optimization step.
 
-        Arguments:
+        Args:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """

--- a/fairseq/optim/composite.py
+++ b/fairseq/optim/composite.py
@@ -134,7 +134,7 @@ class CompositeOptimizer(torch.optim.Optimizer):
     def step(self, closure=None, groups=None):
         """Performs a single optimization step.
 
-        Arguments:
+        Args:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """

--- a/fairseq/optim/fused_adam.py
+++ b/fairseq/optim/fused_adam.py
@@ -47,7 +47,7 @@ class FusedAdamV1(torch.optim.Optimizer):
     Compared to the original version in Apex, the fairseq version casts grads
     and params to FP32 internally to support ``--memory-efficient-fp16``.
 
-    Arguments:
+    Args:
         params (iterable): iterable of parameters to optimize or dicts defining
             parameter groups.
         lr (float, optional): learning rate. (default: 1e-3)
@@ -113,7 +113,7 @@ class FusedAdamV1(torch.optim.Optimizer):
 
     def step(self, closure=None, grads=None, scale=1.0, grad_norms=None):
         """Performs a single optimization step.
-        Arguments:
+        Args:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
             grads (list of tensors, optional): weight gradient to use for the

--- a/fairseq/optim/nag.py
+++ b/fairseq/optim/nag.py
@@ -62,7 +62,7 @@ class NAG(Optimizer):
     def step(self, closure=None):
         """Performs a single optimization step.
 
-        Arguments:
+        Args:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue when I was parsing/generating from the TensorFlow—and now PyTorch—codebases: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see pytorch/pytorch/pull/49736