### PR TITLE
docs: fix simple typo, efficieny -> efficiency

### DIFF
--- a/fairseq/modules/dynamic_convolution.py
+++ b/fairseq/modules/dynamic_convolution.py
@@ -257,7 +257,7 @@ class DynamicConv1dTBC(nn.Module):
             weight_expanded = self.weight_dropout_module(weight_expanded, inplace=False)
         else:
             P = self.padding_l
-            # For efficieny, we cut the kernel size and reduce the padding when the kernel is larger than the length
+            # For efficiency, we cut the kernel size and reduce the padding when the kernel is larger than the length
             if K > T and P == K - 1:
                 weight = weight.narrow(2, K - T, T)
                 K, P = T, T - 1

--- a/fairseq/modules/dynamicconv_layer/dynamicconv_layer.py
+++ b/fairseq/modules/dynamicconv_layer/dynamicconv_layer.py
@@ -212,7 +212,7 @@ class DynamicconvLayer(nn.Module):
             weight_expanded = self.weight_dropout_module(weight_expanded, inplace=False)
         else:
             P = self.padding_l
-            # For efficieny, we cut the kernel size and reduce the padding when the kernel is larger than the length
+            # For efficiency, we cut the kernel size and reduce the padding when the kernel is larger than the length
             if K > T and P == K - 1:
                 weight = weight.narrow(2, K - T, T)
                 K, P = T, T - 1


### PR DESCRIPTION
There is a small typo in fairseq/modules/dynamic_convolution.py, fairseq/modules/dynamicconv_layer/dynamicconv_layer.py.

Should read `efficiency` rather than `efficieny`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md