### PR TITLE
Update lang-pairs path and add fixed-dictionary for small models

### DIFF
--- a/examples/m2m_100/README.md
+++ b/examples/m2m_100/README.md
@@ -130,7 +130,7 @@ wget https://dl.fbaipublicfiles.com/m2m_100/418M_last_checkpoint.pt
 wget https://dl.fbaipublicfiles.com/m2m_100/1.2B_last_checkpoint.pt
 
 # Generation:
-fairseq-generate $binarized_data_path --batch-size 32 --path $path_to_model -s en -t fr --remove-bpe 'sentencepiece' --beam 5 --task translation_multi_simple_epoch --lang-pairs language_pairs_small_models --decoder-langtok --encoder-langtok src --gen-subset test > gen_out
+fairseq-generate $binarized_data_path --batch-size 32 --path $path_to_model --fixed-dictionary model_dict.128k.txt -s en -t fr --remove-bpe 'sentencepiece' --beam 5 --task translation_multi_simple_epoch --lang-pairs language_pairs_small_models.txt --decoder-langtok --encoder-langtok src --gen-subset test > gen_out
 ```
 
 ### 12B Model


### PR DESCRIPTION
With missing file extension in --lang-pairs option generation from 418M and 1.2B Models fails with the following error
```
ValueError: language pair en-fr contains languages that are not in the language dictionary; langs: ['language_pairs_small_models']
```

However generation still fails after restoring file extension with following error:
```
RuntimeError: Error(s) in loading state_dict for TransformerModel:
	size mismatch for encoder.embed_tokens.weight: copying a param with shape torch.Size([128112, 1024]) from checkpoint, the shape in current model is torch.Size([128104, 1024]).
	size mismatch for decoder.embed_tokens.weight: copying a param with shape torch.Size([128112, 1024]) from checkpoint, the shape in current model is torch.Size([128104, 1024]).
	size mismatch for decoder.output_projection.weight: copying a param with shape torch.Size([128112, 1024]) from checkpoint, the shape in current model is torch.Size([128104, 1024]).
```
This could be resolved by adding --fixed-dictionary model_dict.128k.txt like in Generation for the 12B model section.