### PR TITLE
remove minor bug in root path

### DIFF
--- a/examples/speech_to_text/prep_covost_data.py
+++ b/examples/speech_to_text/prep_covost_data.py
@@ -190,7 +190,7 @@ class CoVoST(Dataset):
 
 
 def process(args):
-    root = Path(args.data_root).absolute() / args.src_lang
+    root = Path(args.data_root).absolute()
     if not root.is_dir():
         raise NotADirectoryError(f"{root} does not exist")
     # Extract features


### PR DESCRIPTION
# Before submitting

- [ Yes ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?


## What does this PR do?

- removes a minor bug in line 193 root = Path(args.data_root).absolute() / args.src_lang
- args.data_root is <root>/<src_lang>, no need to add args.src_lang to the path again

python examples/speech_to_text/prep_covost_data.py -d /N/slate/piyush/covost/ru -s ru -t en --vocab-type char 
Traceback (most recent call last):
  File "examples/speech_to_text/prep_covost_data.py", line 280, in <module>
    main()
  File "examples/speech_to_text/prep_covost_data.py", line 276, in main
    process(args)
  File "examples/speech_to_text/prep_covost_data.py", line 195, in process
    raise NotADirectoryError(f"{root} does not exist")
NotADirectoryError: /N/slate/piyush/covost/ru/ru does not exist