### PR TITLE
Fixes #3005

### DIFF
--- a/examples/wav2vec/config/pretraining/wav2vec2_base_librispeech.yaml
+++ b/examples/wav2vec/config/pretraining/wav2vec2_base_librispeech.yaml
@@ -15,6 +15,7 @@ task:
   data: ???
   max_sample_size: 250000
   min_sample_size: 32000
+  normalize: true
 
 dataset:
   num_workers: 6
@@ -53,3 +54,4 @@ model:
   dropout_input: 0.1
   dropout_features: 0.1
   feature_grad_mult: 0.1
+  encoder_embed_dim: 768


### PR DESCRIPTION
The normalize and encoder_embed_dim are not present in base pretraining config which leads to errors during finetuning.



## What does this PR do?
Fixes #3005

