### PR TITLE
Modify eval_bleu_args to Optional

### DIFF
--- a/fairseq/tasks/translation.py
+++ b/fairseq/tasks/translation.py
@@ -228,7 +228,7 @@ class TranslationConfig(FairseqDataclass):
     eval_bleu: bool = field(
         default=False, metadata={"help": "evaluation with BLEU scores"}
     )
-    eval_bleu_args: str = field(
+    eval_bleu_args: Optional[str] = field(
         default="{}",
         metadata={
             "help": 'generation args for BLUE scoring, e.g., \'{"beam": 4, "lenpen": 0.6}\', as JSON string'
@@ -241,7 +241,7 @@ class TranslationConfig(FairseqDataclass):
             "use 'space' to disable detokenization; see fairseq.data.encoders for other options"
         },
     )
-    eval_bleu_detok_args: str = field(
+    eval_bleu_detok_args: Optional[str] = field(
         default="{}",
         metadata={"help": "args for building the tokenizer, if needed, as JSON string"},
     )


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?
Fixes #3158 .

## PR review    
Fixes bug of loading previously trained translation-task model. It is not necessary to define eval_bleu_args and eval_bleu_detok_args when we use eval_bleu=False.

## Did you have fun?
Make sure you had fun coding 🙃
