### PR TITLE
Update dynamic_convolution.py

### DIFF
--- a/fairseq/modules/dynamic_convolution.py
+++ b/fairseq/modules/dynamic_convolution.py
@@ -96,7 +96,7 @@ class DynamicConv1dTBC(nn.Module):
         self,
         input_size,
         kernel_size=1,
-        padding_l=None,
+        padding_l=0,
         num_heads=1,
         weight_dropout=0.0,
         weight_softmax=False,

--- a/fairseq/modules/dynamic_convolution.py
+++ b/fairseq/modules/dynamic_convolution.py
@@ -16,7 +16,7 @@ from .unfold import unfold1d
 def DynamicConv(
     input_size,
     kernel_size=1,
-    padding_l=None,
+    padding_l=1,
     num_heads=1,
     weight_dropout=0.0,
     weight_softmax=False,


### PR DESCRIPTION
There are a lot of default values and I just need to set the input_size in theory. However, the default value of the argument padding_l is None and it will lead an error. So i think you can take the default value of the argument to 0 for preventing errors.

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  

## What does this PR do?
Fixes # (issue).

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
