### PR TITLE
More informative exception when numpy version changes

### DIFF
--- a/fairseq/data/data_utils.py
+++ b/fairseq/data/data_utils.py
@@ -310,7 +310,7 @@ def batch_by_size(
     except ValueError:
         raise ValueError(
             "Please build (or rebuild) Cython components with: `pip install "
-            " --editable .` or `python setup.py build_ext --inplace`. Original "
+            " --editable .` or `python setup.py build_ext --inplace`."
         )
 
     max_tokens = max_tokens if max_tokens is not None else -1

--- a/fairseq/data/data_utils.py
+++ b/fairseq/data/data_utils.py
@@ -307,6 +307,11 @@ def batch_by_size(
             "Please build Cython components with: `pip install --editable .` "
             "or `python setup.py build_ext --inplace`"
         )
+    except ValueError:
+        raise ValueError(
+            "Please build (or rebuild) Cython components with: `pip install "
+            " --editable .` or `python setup.py build_ext --inplace`. Original "
+        )
 
     max_tokens = max_tokens if max_tokens is not None else -1
     max_sentences = max_sentences if max_sentences is not None else -1


### PR DESCRIPTION
More informative exception when numpy version changes to ask the user to recompile Cython files

# Before submitting

- [With @myleott  ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [N/A ] Did you make sure to update the docs?   
- [N/A ] Did you write any new necessary tests?  


## What does this PR do?
Raises a more informative error to tell the user to recompile Cython files after an update to the numpy version.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
