### PR TITLE
fix a bug in compute_mask_indices() for wav2vec

### DIFF
--- a/fairseq/data/data_utils.py
+++ b/fairseq/data/data_utils.py
@@ -476,7 +476,7 @@ def compute_mask_indices(
                 new_parts = []
                 if span_start - s - min_space >= keep_length:
                     new_parts.append((s, span_start - min_space + 1))
-                if e - span_start - keep_length - min_space > keep_length:
+                if e - span_start - length - min_space > keep_length:
                     new_parts.append((span_start + length + min_space, e))
                 return new_parts
 


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  

## What does this PR do?
Fixes a bug in the no_overlap case when computing mask indices for wav2vec

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
