### PR TITLE
fixing reordering bug in BARTHubInterface.generate

### DIFF
--- a/fairseq/models/bart/hub_interface.py
+++ b/fairseq/models/bart/hub_interface.py
@@ -111,7 +111,11 @@ class BARTHubInterface(GeneratorHubInterface):
                 skip_invalid_size_inputs=skip_invalid_size_inputs,
                 **kwargs
             )
-            res.extend(results)
+            for id, hypos in zip(batch["id"].tolist(), results):
+                res.append((id, hypos))
+                
+        # sort output to match input order
+        res = [hypos for _, hypos in sorted(res, key=lambda x: x[0])]
         return res
 
     def extract_features(


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  

## What does this PR do?
Fixes reordering when calling `BARTHubInterface.generate`. Without reordering, if we call the function with a batch of sentences, the output order is arbitrary and this is a bug. This PR fixes this.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
