### PR TITLE
fix bug - sentence bleu in score.py

### DIFF
--- a/fairseq_cli/score.py
+++ b/fairseq_cli/score.py
@@ -64,7 +64,13 @@ def cli_main():
 
         def score(fdsys):
             with open(args.ref) as fdref:
-                scorer = bleu.Scorer(dict.pad(), dict.eos(), dict.unk())
+                scorer = bleu.Scorer(
+                    bleu.BleuConfig(
+                        pad=dict.pad(),
+                        eos=dict.eos(),
+                        unk=dict.unk(),
+                    )
+                )
                 for i, (sys_tok, ref_tok) in enumerate(
                     zip(readlines(fdsys), readlines(fdref))
                 ):


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?
Fix a bug in score.py with --sentence_bleu. Scorer must use BleuConfig.
(related [commit](https://github.com/pytorch/fairseq/commit/3b27ed7996b0315f471c795cf9b7dfcc18467cbe#diff-b741b1f7738ef6a2b9c5697b09367c97b74b98f0eb3c998e03346943e40cce7c))

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
😄 
