### PR TITLE
add recommendation to build_ext and install user code

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,10 @@ and [RoBERTa](https://pytorch.org/hub/pytorch_fairseq_roberta/) for more example
 ``` bash
 git clone https://github.com/pytorch/fairseq
 cd fairseq
-pip install --editable ./
+pip install --user --global-option="build_ext" --editable ./
 
 # on MacOS:
-# CFLAGS="-stdlib=libc++" pip install --editable ./
+# CFLAGS="-stdlib=libc++" pip install --user --global-option="build_ext" --editable ./
 
 # to install the latest stable release (0.10.x)
 # pip install fairseq


### PR DESCRIPTION
Some functionalities of fairseq are accessible only when building extensions and making them available as user command. Would it be helpful to update the README in some way to make that information more accessible?

For instance, I find this workflow quite useful:
```
❯ conda create -n torch-stable python==3.8 parameterized numpy scipy pytest torchaudio pytorch -c pytorch
❯ conda activate torch-stable
❯ pip install soundfile
❯ git clone https://github.com/pytorch/fairseq
❯ pip install --verbose --user --global-option="build_ext" --editable ./fairseq
❯ # fairseq-hydra-train task.data=... --config-dir ... --config-name ...
❯ # pip uninstall fairseq
```

Even if this pull request is closed without merge, its suggestion remains discoverable and hopefully helpful to other users :)

cc #2106