### PR TITLE
Fix wav2vec2 typo

### DIFF
--- a/examples/wav2vec/README.md
+++ b/examples/wav2vec/README.md
@@ -151,7 +151,7 @@ To get raw numbers, use --w2l-decoder viterbi and omit the lexicon. To use the t
 
 Wav2Vec2 is also available in the [🤗Transformers library](https://github.com/huggingface/transformers) since version 4.3.
 
-Pretrained Models can be found on the [hub](https://huggingface.co/models?filter=wav2vec2) 
+Pretrained Models can be found on the [hub](https://huggingface.co/models?filter=wav2vec2)
 and documentation can be found [here](https://huggingface.co/transformers/master/model_doc/wav2vec2.html).
 
 Usage example:
@@ -248,8 +248,8 @@ Roberta on K-means codes | [Librispeech](http://www.openslr.org/12) | [download]
 import torch
 import fairseq
 
-cp = torch.load('/path/to/vq-wav2vec.pt')
-model, cfg, task = fairseq.checkpoint_utils.load_model_ensemble_and_task([cp])
+cp_path = '/path/to/vq-wav2vec.pt'
+model, cfg, task = fairseq.checkpoint_utils.load_model_ensemble_and_task([cp_path])
 model = model[0]
 model.eval()
 


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?
It addresses what I believe is a typo in the wav2vec2 docs.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
