### PR TITLE
A quick fix to make pip installation on Windows 10 work.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
+import shutil
 import subprocess
 import sys
 from setuptools import setup, find_packages, Extension
@@ -247,7 +248,10 @@ if __name__ == "__main__":
         # symlink examples into fairseq package so package_data accepts them
         fairseq_examples = os.path.join("fairseq", "examples")
         if "build_ext" not in sys.argv[1:] and not os.path.exists(fairseq_examples):
-            os.symlink(os.path.join("..", "examples"), fairseq_examples)
+            if os.name == 'nt':
+                shutil.copytree("examples", fairseq_examples)
+            else:
+                os.symlink(os.path.join("..", "examples"), fairseq_examples)
 
         package_data = {
             "fairseq": (
@@ -257,4 +261,7 @@ if __name__ == "__main__":
         do_setup(package_data)
     finally:
         if "build_ext" not in sys.argv[1:] and os.path.islink(fairseq_examples):
-            os.unlink(fairseq_examples)
+            if os.name == 'nt':
+                shutil.rmtree(fairseq_examples)
+            else:
+                os.unlink(fairseq_examples)


### PR DESCRIPTION
This is a proposed quick fix for #3194 (https://github.com/pytorch/fairseq/issues/3194)
On Windows 10, creating a symlink requires super user priviledges, so I changed the code to use a copytree instead.
This seems OK since the data volume to be copied is small. LMK

No tests were added since this an installation script and my goal is to show that a simple solution to the issue exists.