### PR TITLE
Correction of decoder output of simultaneous agent after recent update

### DIFF
--- a/examples/speech_to_text/simultaneous_translation/agents/fairseq_simul_st_agent.py
+++ b/examples/speech_to_text/simultaneous_translation/agents/fairseq_simul_st_agent.py
@@ -334,7 +334,7 @@ class FairseqSimulSTAgent(SpeechAgent):
 
         torch.cuda.empty_cache()
 
-        if outputs["action"] == 0:
+        if outputs.action == 0:
             return READ_ACTION
         else:
             return WRITE_ACTION


### PR DESCRIPTION
Correction in the use of decoder output that now is a NamedTuple and not a dict anymore

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?
Fixes # (issue).

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
