### PR TITLE
hub_utils: fix logging of src tokens

### DIFF
--- a/fairseq/hub_utils.py
+++ b/fairseq/hub_utils.py
@@ -185,7 +185,7 @@ class GeneratorHubInterface(nn.Module):
                 return getattr(gen_args, name, getattr(self.cfg, name, default))
 
             for source_tokens, target_hypotheses in zip(tokenized_sentences, outputs):
-                src_str_with_unk = self.string(source_tokens)
+                src_str_with_unk = self.src_dict.string(source_tokens)
                 logger.info("S\t{}".format(src_str_with_unk))
                 for hypo in target_hypotheses:
                     hypo_str = self.decode(hypo["tokens"])


### PR DESCRIPTION
tokens logging was using the tgt_dict on src tokens

## Description
In `GeneratorHubInterface.generate`, we attempt to log the stringified source tokens in `logger.info("S\t{}".format(self.string(source_tokens)))`. However `self.string` uses the `tgt_dict` for the conversion, so we're applying the `tgt_dict` to source tokens! This PR fixes that bug by using the `src_dict` on the logged source tokens.

