### PR TITLE
Fix path typo in simultaneous translation README

### DIFF
--- a/examples/simultaneous_translation/docs/ende-mma.md
+++ b/examples/simultaneous_translation/docs/ende-mma.md
@@ -16,7 +16,7 @@ Another example of training an English to Japanese model can be found [here](doc
 fairseq-train \
     data-bin/wmt15_en_de_32k \
     --simul-type infinite_lookback \
-    --user-dir $FAIRSEQ/example/simultaneous_translation \
+    --user-dir $FAIRSEQ/examples/simultaneous_translation \
     --mass-preservation \
     --criterion latency_augmented_label_smoothed_cross_entropy \
     --latency-weight-avg  0.1 \
@@ -37,7 +37,7 @@ fairseq-train \
 fairseq-train \
     data-bin/wmt15_en_de_32k \
     --simul-type hard_aligned \
-    --user-dir $FAIRSEQ/example/simultaneous_translation \
+    --user-dir $FAIRSEQ/examples/simultaneous_translation \
     --mass-preservation \
     --criterion latency_augmented_label_smoothed_cross_entropy \
     --latency-weight-var  0.1 \
@@ -59,7 +59,7 @@ fairseq-train \
     data-bin/wmt15_en_de_32k \
     --simul-type wait-k \
     --waitk-lagging 3 \
-    --user-dir $FAIRSEQ/example/simultaneous_translation \
+    --user-dir $FAIRSEQ/examples/simultaneous_translation \
     --mass-preservation \
     --criterion latency_augmented_label_smoothed_cross_entropy \
     --max-update 50000 \


### PR DESCRIPTION
minor typo in README

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?
Fixes typo in the README

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
