### PR TITLE
Escape % in `keep_interval_updates_pattern` help description

### DIFF
--- a/fairseq/dataclass/configs.py
+++ b/fairseq/dataclass/configs.py
@@ -576,7 +576,7 @@ class CheckpointConfig(FairseqDataclass):
         metadata={
             "help": "when used with --keep-interval-updates, skips deleting "
                     "any checkpoints with update X where "
-                    "X % keep_interval_updates_pattern == 0"
+                    "X %% keep_interval_updates_pattern == 0"
         },
     )
     keep_last_epochs: int = field(


### PR DESCRIPTION
This leads to the following error:

```
ValueError: unsupported format character 'k' (0x6b) at index 95
```

Resolves #3491

### Test:

`fairseq-train --help`

Produces:

```
...
  --keep-interval-updates-pattern KEEP_INTERVAL_UPDATES_PATTERN
                        when used with --keep-interval-updates, skips deleting any checkpoints with update X where X % keep_interval_updates_pattern == 0
...
```

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  

## What does this PR do?
Fixes # (issue).
#3491 
## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
