### PR TITLE
disable raise_if_valid_subsets_unintentionally_ignored check for dummy tasks

### DIFF
--- a/fairseq/data/data_utils.py
+++ b/fairseq/data/data_utils.py
@@ -583,6 +583,7 @@ def raise_if_valid_subsets_unintentionally_ignored(train_cfg) -> None:
         train_cfg.dataset.ignore_unused_valid_subsets
         or train_cfg.dataset.combine_valid_subsets
         or train_cfg.dataset.disable_validation
+        or not hasattr(train_cfg.task, "data")
     ):
         return
     other_paths = _find_extra_valid_paths(train_cfg.task.data)

--- a/tests/test_valid_subset_checks.py
+++ b/tests/test_valid_subset_checks.py
@@ -10,18 +10,20 @@ from .utils import create_dummy_data, preprocess_lm_data, train_language_model
 
 
 def make_lm_config(
-    data_dir,
+    data_dir=None,
     extra_flags=None,
     task="language_modeling",
     arch="transformer_lm_gpt2_tiny",
 ):
+    task_args = [task]
+    if data_dir is not None:
+        task_args += [data_dir]
     train_parser = options.get_training_parser()
     train_args = options.parse_args_and_arch(
         train_parser,
         [
             "--task",
-            task,
-            data_dir,
+            *task_args,
             "--arch",
             arch,
             "--optimizer",
@@ -96,6 +98,10 @@ class TestValidSubsetsErrors(unittest.TestCase):
     def test_disable_validation(self):
         self._test_case([], ["--disable-validation"])
         self._test_case(["valid", "valid1"], ["--disable-validation"])
+
+    def test_dummy_task(self):
+        cfg = make_lm_config(task="dummy_lm")
+        raise_if_valid_subsets_unintentionally_ignored(cfg)
 
 
 class TestCombineValidSubsets(unittest.TestCase):


### PR DESCRIPTION
Fixes the following crash:
```python
Traceback (most recent call last):
  File "/private/home/msb/.conda/envs/fairseq-20210102-pt181/lib/python3.8/site-packages/torch/multiprocessing/spawn.py", line 59, in _wrap
    fn(i, *args)
  File "/private/home/msb/code/fairseq/fairseq/distributed/utils.py", line 328, in distributed_main
    main(cfg, **kwargs)
  File "/private/home/msb/code/fairseq/fairseq_cli/train.py", line 117, in main
    data_utils.raise_if_valid_subsets_unintentionally_ignored(cfg)
  File "/private/home/msb/code/fairseq/fairseq/data/data_utils.py", line 584, in raise_if_valid_subsets_unintentionally_ignored
    other_paths = _find_extra_valid_paths(train_cfg.task.data)
AttributeError: 'Namespace' object has no attribute 'data'
```
