### PR TITLE
fix the error when using pyarrow for raw_audio_dataset

### DIFF
--- a/fairseq/data/audio/raw_audio_dataset.py
+++ b/fairseq/data/audio/raw_audio_dataset.py
@@ -299,7 +299,7 @@ class FileAudioDataset(RawAudioDataset):
     def __getitem__(self, index):
         import soundfile as sf
 
-        path_or_fp = os.path.join(self.root_dir, self.fnames[index])
+        path_or_fp = os.path.join(self.root_dir, str(self.fnames[index]))
         _path, slice_ptr = parse_path(path_or_fp)
         if len(slice_ptr) == 2:
             byte_data = read_from_stored_zip(_path, slice_ptr[0], slice_ptr[1])


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [X] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- [X] Did you write any new necessary tests?  

## What does this PR do?

fix the error when using pyarrow for raw_audio_dataset, Currently there is an error `TypeError: join() argument must be str, bytes, or os.PathLike object, not 'StringScalar'`. In this PR I just convert the type to string in `__getitem__()` for `os.path.join()`

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
