### PR TITLE
fix the issue of need_weights is never used in the wav2vec2 model

### DIFF
--- a/fairseq/models/wav2vec/wav2vec2.py
+++ b/fairseq/models/wav2vec/wav2vec2.py
@@ -980,6 +980,7 @@ class TransformerSentenceEncoderLayer(nn.Module):
                 key=x,
                 value=x,
                 key_padding_mask=self_attn_padding_mask,
+                need_weights=need_weights,
                 attn_mask=self_attn_mask,
             )
             x = self.dropout1(x)
@@ -998,6 +999,7 @@ class TransformerSentenceEncoderLayer(nn.Module):
                 key=x,
                 value=x,
                 key_padding_mask=self_attn_padding_mask,
+                need_weights=need_weights,
             )
 
             x = self.dropout1(x)


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [z] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- [z] Did you write any new necessary tests?  

## What does this PR do?
fixes the issue of `need_weights` is never used in the wav2vec2 model.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
