### PR TITLE
[Hubert] Fix padding mask

### DIFF
--- a/fairseq/models/hubert/hubert.py
+++ b/fairseq/models/hubert/hubert.py
@@ -229,6 +229,7 @@ class HubertModel(BaseFairseqModel):
         logger.info(f"HubertModel Config: {cfg}")
 
         feature_enc_layers = eval(cfg.conv_feature_layers)  # noqa
+        self.cfg = cfg
         self.embed = feature_enc_layers[-1][0]
 
         self.feature_extractor = ConvFeatureExtractionModel(
@@ -397,16 +398,36 @@ class HubertModel(BaseFairseqModel):
         target_list = [t[:, target_inds.long()] for t in target_list]
         return features, target_list
 
+    def _get_feat_extract_output_lengths(self, input_lengths: torch.LongTensor):
+        """
+        Computes the output length of the convolutional layers
+        """
+
+        def _conv_out_length(input_length, kernel_size, stride):
+            return torch.floor((input_length - kernel_size) / stride + 1)
+
+        conv_cfg_list = eval(self.cfg.conv_feature_layers)
+
+        for i in range(len(conv_cfg_list)):
+            input_lengths = _conv_out_length(input_lengths, conv_cfg_list[i][1], conv_cfg_list[i][2])
+
+        return input_lengths.to(torch.long)
+
     def forward_padding_mask(
         self, features: torch.Tensor, padding_mask: torch.Tensor,
     ) -> torch.Tensor:
-        extra = padding_mask.size(1) % features.size(1)
-        if extra > 0:
-            padding_mask = padding_mask[:, :-extra]
-        padding_mask = padding_mask.view(
-            padding_mask.size(0), features.size(1), -1
+        input_lengths = (1 - padding_mask.long()).sum(-1)
+        # apply conv formula to get real output_lengths
+        output_lengths = self._get_feat_extract_output_lengths(input_lengths)
+
+        padding_mask = torch.zeros(
+            features.shape[:2], dtype=features.dtype, device=features.device
         )
-        padding_mask = padding_mask.all(-1)
+
+        # these two operations makes sure that all values
+        # before the output lengths indices are attended to
+        padding_mask[(torch.arange(padding_mask.shape[0], device=padding_mask.device), output_lengths - 1)] = 1
+        padding_mask = (1 - padding_mask.flip([-1]).cumsum(-1).flip([-1])).bool()
         return padding_mask
 
     def forward(


### PR DESCRIPTION
This PR is a copy of https://github.com/pytorch/fairseq/pull/3228 for Hubert. Wav2Vec2 had an issue with the padding mask which was solved in https://github.com/pytorch/fairseq/pull/3228. Hubert seems to have the same problem as Wav2vec2 (see: https://github.com/pytorch/fairseq/issues/3227) so that the padding mask should be corrected accordingly.

## What does this PR do?
Fixes https://github.com/pytorch/fairseq/issues/3227 for Hubert

## PR review    
@hikushalhere
@alexeib 

## Did you have fun?
Make sure you had fun coding 🙃
