### PR TITLE
Fix #3575  the overflow error.

### DIFF
--- a/fairseq/modules/transformer_layer.py
+++ b/fairseq/modules/transformer_layer.py
@@ -125,7 +125,10 @@ class TransformerEncoderLayer(nn.Module):
         # the attention weight (before softmax) for some padded element in query
         # will become -inf, which results in NaN in model parameters
         if attn_mask is not None:
-            attn_mask = attn_mask.masked_fill(attn_mask.to(torch.bool), -1e8)
+            if attn_mask.dtype is torch.float16:
+                attn_mask = attn_mask.masked_fill(attn_mask.to(torch.bool), -6e4)
+            else:
+                attn_mask = attn_mask.masked_fill(attn_mask.to(torch.bool), -1e8)
 
         residual = x
         if self.normalize_before:


### PR DESCRIPTION
For fp16 case, we set the value to -6e4 instead of -1e8 to prevent overflow error.


## What does this PR do?
Fixes #3575 .

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
