### PR TITLE
fix logging when running single-process

### DIFF
--- a/fairseq_cli/train.py
+++ b/fairseq_cli/train.py
@@ -14,6 +14,15 @@ import os
 import sys
 from typing import Dict, Optional, Any, List, Tuple, Callable
 
+# We need to setup root logger before importing any fairseq libraries.
+logging.basicConfig(
+    format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    level=os.environ.get("LOGLEVEL", "INFO").upper(),
+    stream=sys.stdout,
+)
+logger = logging.getLogger("fairseq_cli.train")
+
 import numpy as np
 import torch
 from fairseq import (
@@ -35,13 +44,6 @@ from fairseq.trainer import Trainer
 from omegaconf import DictConfig, OmegaConf
 
 
-logging.basicConfig(
-    format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
-    datefmt="%Y-%m-%d %H:%M:%S",
-    level=os.environ.get("LOGLEVEL", "INFO").upper(),
-    stream=sys.stdout,
-)
-logger = logging.getLogger("fairseq_cli.train")
 
 
 def main(cfg: FairseqConfig) -> None:


### PR DESCRIPTION
In file_io.py, there is a logging message that happens in the global
scope. This logging message can be invoked before calling
logging.basicConfig() in fairseq_cli/train.py resulting in that
call becoming a no-op. This was causing the loglevel to remain at
WARNING.

Fix is to call logging.basicConfig() before import-ing any fairseq
libraries that may do logging in global scope.

Verified that I logging.info messages are now visible after applying
this PR.

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?
Fixes # (issue).

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
