### PR TITLE
[Hubert] Enabled storing of dictionaries

### DIFF
--- a/examples/hubert/config/finetune/base_10h.yaml
+++ b/examples/hubert/config/finetune/base_10h.yaml
@@ -23,6 +23,7 @@ distributed_training:
 task:
   _name: hubert_pretraining
   data: ???
+  fine_tuning: true
   label_dir: ???
   normalize: false  # must be consistent with pre-training
   labels: ["ltr"]

--- a/fairseq/tasks/hubert_pretraining.py
+++ b/fairseq/tasks/hubert_pretraining.py
@@ -115,12 +115,13 @@ class HubertPretrainingTask(FairseqTask):
         logger.info(f"current directory is {os.getcwd()}")
         logger.info(f"HubertPretrainingTask Config {cfg}")
 
+        self.cfg = cfg
         self.fine_tuning = cfg.fine_tuning
 
         if cfg.fine_tuning:
-            self.state.add_factory("target_dictionary", lambda: self.load_dictionaries(cfg)[0])
+            self.state.add_factory("target_dictionary", lambda: self.load_dictionaries)
         else:
-            self.state.add_factory("dictionaries", lambda: self.load_dictionaries(cfg))
+            self.state.add_factory("dictionaries", lambda: self.load_dictionaries)
 
         self._source_dictionary = None
 
@@ -144,9 +145,10 @@ class HubertPretrainingTask(FairseqTask):
     ) -> "HubertPretrainingTask":
         return cls(cfg)
 
-    def load_dictionaries(self, cfg: HubertPretrainingConfig):
-        label_dir = cfg.data if cfg.label_dir is None else cfg.label_dir
-        return [Dictionary.load(f"{label_dir}/dict.{label}.txt") for label in cfg.labels]
+    def load_dictionaries(self):
+        label_dir = self.cfg.data if self.cfg.label_dir is None else self.cfg.label_dir
+        dictionaries = return [Dictionary.load(f"{label_dir}/dict.{label}.txt") for label in self.cfg.labels]
+        return dictionaries[0] if self.cfg.fine_tuning else dictionaries
 
     def get_label_dir(self) -> str:
         if self.cfg.label_dir is None:

--- a/fairseq/tasks/hubert_pretraining.py
+++ b/fairseq/tasks/hubert_pretraining.py
@@ -146,18 +146,6 @@ class HubertPretrainingTask(FairseqTask):
     def dictionaries(self) -> List[Dictionary]:
         return [self._dictionaries[l] for l in self.cfg.labels]
 
-    @property
-    def pt_dictionaries(self) -> Optional[Dictionary]:
-        if self.fine_tuning:
-            logger.warning("Attempting to access pre-training dictionary during fine-tuning")
-        return self.state.pt_dictionaries
-
-    @property
-    def ft_dictioanries(self) -> Optional[Dictionary]:
-        if not self.fine_tuning:
-            logger.warning("Attempting to access fine-tuning dictionary during pre-training")
-        return self.state.ft_dictionaries
-
     @classmethod
     def setup_task(
         cls, cfg: HubertPretrainingConfig, **kwargs

--- a/fairseq/tasks/hubert_pretraining.py
+++ b/fairseq/tasks/hubert_pretraining.py
@@ -114,7 +114,9 @@ class HubertPretrainingTask(FairseqTask):
 
         logger.info(f"current directory is {os.getcwd()}")
         logger.info(f"HubertPretrainingTask Config {cfg}")
-        
+
+        self.fine_tuning = cfg.fine_tuning
+
         if cfg.fine_tuning:
             self.state.add_factory("ft_dictionaries", lambda: self.dictionaries_factory(cfg))
             self._dictionaries = self.state.ft_dictionaries
@@ -146,15 +148,15 @@ class HubertPretrainingTask(FairseqTask):
 
     @property
     def pt_dictionaries(self) -> Optional[Dictionary]:
-        if cfg.fine_tuning:
+        if self.fine_tuning:
             logger.warning("Attempting to access pre-training dictionary during fine-tuning")
         return self.state.pt_dictionaries
 
     @property
     def ft_dictioanries(self) -> Optional[Dictionary]:
-        if not cfg.fine_tuning:
+        if not self.fine_tuning:
             logger.warning("Attempting to access fine-tuning dictionary during pre-training")
-        return self.state.ft_dictionaries        
+        return self.state.ft_dictionaries
 
     @classmethod
     def setup_task(

--- a/fairseq/tasks/hubert_pretraining.py
+++ b/fairseq/tasks/hubert_pretraining.py
@@ -147,7 +147,7 @@ class HubertPretrainingTask(FairseqTask):
 
     def load_dictionaries(self):
         label_dir = self.cfg.data if self.cfg.label_dir is None else self.cfg.label_dir
-        dictionaries = return [Dictionary.load(f"{label_dir}/dict.{label}.txt") for label in self.cfg.labels]
+        dictionaries = [Dictionary.load(f"{label_dir}/dict.{label}.txt") for label in self.cfg.labels]
         return dictionaries[0] if self.cfg.fine_tuning else dictionaries
 
     def get_label_dir(self) -> str:

--- a/fairseq/tasks/hubert_pretraining.py
+++ b/fairseq/tasks/hubert_pretraining.py
@@ -114,10 +114,14 @@ class HubertPretrainingTask(FairseqTask):
         logger.info(f"HubertPretrainingTask Config {cfg}")
         
         self.state.add_factory("dictionaries", lambda: self.dictionaries_factory(cfg))
-        self.state.add_factory("target_dictionary", self.target_dictionary_factory)
 
         self._dictionaries = self.state.dictionaries
-        self._target_dictionary = self.state.target_dictionary
+        if len(self._dictionaries) == 1:
+            self._target_dictionary =  self._dictionaries[list(self._dictionaries)[0]]
+        else:
+            logger.info("Multiple Dictionaries, cannot pick single target.")
+            self._target_dictionary =  {}
+        
         self._source_dictionary = None
 
         self.blank_symbol = "<s>"
@@ -148,12 +152,6 @@ class HubertPretrainingTask(FairseqTask):
             else None
             for label in cfg.labels
         }
-
-    def target_dictionary_factory(self):
-        if len(self._dictionaries) == 1:
-            logger.info(self._dictionaries)
-            return self._dictionaries[list(self._dictionaries)[0]]
-        return None
 
     def get_label_dir(self) -> str:
         if self.cfg.label_dir is None:

--- a/fairseq/tasks/hubert_pretraining.py
+++ b/fairseq/tasks/hubert_pretraining.py
@@ -112,16 +112,16 @@ class HubertPretrainingTask(FairseqTask):
 
         logger.info(f"current directory is {os.getcwd()}")
         logger.info(f"HubertPretrainingTask Config {cfg}")
-        
+
         self.state.add_factory("dictionaries", lambda: self.dictionaries_factory(cfg))
 
         self._dictionaries = self.state.dictionaries
         if len(self._dictionaries) == 1:
-            self._target_dictionary =  self._dictionaries[list(self._dictionaries)[0]]
+            self._target_dictionary = self._dictionaries[list(self._dictionaries)[0]]
         else:
             logger.info("Multiple Dictionaries, cannot pick single target.")
-            self._target_dictionary =  {}
-        
+            self._target_dictionary = {}
+
         self._source_dictionary = None
 
         self.blank_symbol = "<s>"
@@ -143,7 +143,7 @@ class HubertPretrainingTask(FairseqTask):
         cls, cfg: HubertPretrainingConfig, **kwargs
     ) -> "HubertPretrainingTask":
         return cls(cfg)
-        
+
     def dictionaries_factory(self, cfg: HubertPretrainingConfig):
         label_dir = cfg.data if cfg.label_dir is None else cfg.label_dir
         return {


### PR DESCRIPTION
## What does this PR do?
For HubertPretrainingTask, added dictionaries to the task state to enable the serialization of the dictionaries (thus removing the need to load from the disk after training)

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.


### Test Plan
To verify the success, run the Hubert Pretraining pipeline, load a checkpoint model, and verify that the "dictionaries" key is present in the state within the model.

Specifically, 
```
PYTHONPATH=. python /path/to/fairseq/fairseq_cli/hydra_train.py -m \
        --config-dir ${fairseq_dir}/examples/hubert/config/pretrain \
        --config-name hubert_base_librispeech \
        hydra/launcher=submitit_local \
        hydra.launcher.gpus_per_node=2 \
        hydra.launcher.cpus_per_task=8 \
        hydra.launcher.mem_gb=384 \
        task.data=${tsv_dir} \
        task.label_dir=${km_dir} \
        task.labels=["km"] \
        +data=iter1 \
        optimization.max_update=250 \
        hydra.sweep.dir=${exp_dir} \
        hydra.run.dir=${exp_dir} > ${exp_dir}/log.out 2> ${exp_dir}/log.err &
```
Then, at the location of the model, load the model using `pytorch.load`, and verifying that "dictionaries" is a key under the `task_state` key of the model.


## Did you have fun?
Make sure you had fun coding 🙃
