### PR TITLE
Fix translation_moe task src path and dropout arg when executing paraphraser example

### DIFF
--- a/examples/paraphraser/paraphrase.py
+++ b/examples/paraphraser/paraphrase.py
@@ -39,7 +39,7 @@ def main():
         args.user_dir = os.path.join(
             os.path.dirname(os.path.dirname(os.path.abspath(__file__))),  # examples/
             "translation_moe",
-            "src",
+            "translation_moe_src",
         )
         if os.path.exists(args.user_dir):
             logging.info("found user_dir:" + args.user_dir)

--- a/fairseq/checkpoint_utils.py
+++ b/fairseq/checkpoint_utils.py
@@ -625,6 +625,14 @@ def _upgrade_state_dict(state):
         ]:
             if key in state["args"]:
                 delattr(state["args"], key)
+        if hasattr(state["args"], "mean_pool_gating_network_dropout"):
+	    if (
+            (state["args"].mean_pool_gating_network_dropout == None)
+                and
+            (state["args"].mean_pool_gating_network_encoder_dim == None)
+            ):
+                state["args"].mean_pool_gating_network_dropout = 0
+                state["args"].mean_pool_gating_network_encoder_dim = 0
 
         state["cfg"] = convert_namespace_to_omegaconf(state["args"])
 


### PR DESCRIPTION
Fixes #3604 correcting the path to src and the dropout arg.

