### PR TITLE
Hydra 1.1 compatibility: Use an explicit schema for the primary config

### DIFF
--- a/fairseq/checkpoint_utils.py
+++ b/fairseq/checkpoint_utils.py
@@ -203,7 +203,7 @@ def load_checkpoint(cfg: CheckpointConfig, trainer, **passthrough_args):
         cfg.restore_file == "checkpoint_last.pt"
     ):  # default value of restore_file is 'checkpoint_last.pt'
         checkpoint_path = os.path.join(
-            cfg.save_dir, "checkpoint_last{}.pt".format(suffix)
+            cfg.get("save_dir"), "checkpoint_last{}.pt".format(suffix)
         )
         first_launch = not PathManager.exists(checkpoint_path)
         if cfg.finetune_from_model is not None and first_launch:

--- a/fairseq/config/config.yaml
+++ b/fairseq/config/config.yaml
@@ -5,6 +5,7 @@ hydra:
     dir: .
 
 defaults:
+    - config_schema
     - task: null
     - model: null
     - criterion: cross_entropy

--- a/fairseq/dataclass/initialize.py
+++ b/fairseq/dataclass/initialize.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 def hydra_init(cfg_name="config") -> None:
 
     cs = ConfigStore.instance()
-    cs.store(name=cfg_name, node=FairseqConfig)
+    cs.store(name=f"{cfg_name}_schema", node=FairseqConfig)
 
     for k in FairseqConfig.__dataclass_fields__:
         v = FairseqConfig.__dataclass_fields__[k].default


### PR DESCRIPTION
## What does this PR do?
Fixes compatibility with Hydra 1.1.
The result is compatible with both Hydra 1.0 and Hydra 1.1, and will allow a smoother migration to Hydra 1.1.

At this point I am not yet removing the restriction on the Hydra version from setup.py:
1. It depends on some Hydra 1.1 changes that are not yet released (It will be compatible with 1.1.1).
2. Upgrading will result in deprecation warnings, and fixing them will break compatibility with Hydra 1.0.

There will be some followup to make the code fully compatible with 1.1 once Hydra 1.1 is the default version in fbcode.