### PR TITLE
removed numpy version restriction on Python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -193,8 +193,7 @@ def do_setup(package_data):
         long_description_content_type="text/markdown",
         setup_requires=[
             "cython",
-            'numpy<1.20.0; python_version<"3.7"',
-            'numpy; python_version>="3.7"',
+            'numpy',
             "setuptools>=18.0",
         ],
         install_requires=[


### PR DESCRIPTION
This is conflicting with a recent change on fairscale:

https://github.com/facebookresearch/fairscale/pull/731