### PR TITLE
fixes tests/test_train.py to mock checkpoint.save_dir config node

### DIFF
--- a/fairseq/checkpoint_utils.py
+++ b/fairseq/checkpoint_utils.py
@@ -203,7 +203,7 @@ def load_checkpoint(cfg: CheckpointConfig, trainer, **passthrough_args):
         cfg.restore_file == "checkpoint_last.pt"
     ):  # default value of restore_file is 'checkpoint_last.pt'
         checkpoint_path = os.path.join(
-            cfg.get("save_dir"), "checkpoint_last{}.pt".format(suffix)
+            cfg.save_dir, "checkpoint_last{}.pt".format(suffix)
         )
         first_launch = not PathManager.exists(checkpoint_path)
         if cfg.finetune_from_model is not None and first_launch:

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -61,6 +61,7 @@ def get_mock_cfg(finetune_from_model):
     cfg_mock = OmegaConf.create(
         {
             "checkpoint": {
+                "save_dir": None,
                 "optimizer_overrides": "{}",
                 "reset_dataloader": False,
                 "reset_meters": False,


### PR DESCRIPTION
## What does this PR do?
Some downstream users reported that errors when passing Namespace to load_checkpoint().

A recent change made the assumption that the passed object is dict like (dict or DictConfig) that have a get function.
This changes that and make sure the mocked config have checkpoint.save_dir to allow the test to run.