### PR TITLE
Fixed the `positions` argument being ignored.

### DIFF
--- a/fairseq/modules/positional_embedding.py
+++ b/fairseq/modules/positional_embedding.py
@@ -27,9 +27,11 @@ def PositionalEmbedding(
         if padding_idx is not None:
             nn.init.constant_(m.weight[padding_idx], 0)
     else:
+        if padding_idx is not None:
+            num_embeddings = num_embeddings + padding_idx + 1
         m = SinusoidalPositionalEmbedding(
             embedding_dim,
             padding_idx,
-            init_size=num_embeddings + padding_idx + 1,
+            init_size=num_embeddings,
         )
     return m

--- a/fairseq/modules/sinusoidal_positional_embedding.py
+++ b/fairseq/modules/sinusoidal_positional_embedding.py
@@ -65,10 +65,6 @@ class SinusoidalPositionalEmbedding(nn.Module):
         positions: Optional[Tensor] = None,
     ):
         """Input is expected to be of size [bsz x seqlen]."""
-        assert (positions is None) or (
-            self.padding_idx is None
-        ), "If positions is pre-computed then padding_idx should not be set."
-
         bspair = torch.onnx.operators.shape_as_tensor(input)
         bsz, seq_len = bspair[0], bspair[1]
         max_pos = self.padding_idx + 1 + seq_len


### PR DESCRIPTION
The `positions` argument is passed in
`LearnedPositionalEmbedding.forward()`, while it is ignored in
`SinusoidalPositionalEmbedding.forward()`.

The method has been fixed to use the argument when passed.

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?
Above-mentioned.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
