### PR TITLE
Make FSDP and --update-freq play nice

### DIFF
--- a/fairseq/trainer.py
+++ b/fairseq/trainer.py
@@ -61,7 +61,7 @@ class Trainer(object):
         else:
             self.device = torch.device("cpu")
 
-        if self.cfg.distributed_training.ddp_backend == "fully_sharded":
+        if self.is_fsdp:
             if self.cfg.common.bf16:
                 raise ValueError(
                     "FullyShardedDataParallel is not compatible with --bf16 or "
@@ -88,7 +88,7 @@ class Trainer(object):
         # copy model and criterion to current device/dtype
         self._criterion = criterion
         self._model = model
-        if cfg.distributed_training.ddp_backend != "fully_sharded":
+        if not self.is_fsdp:
             if cfg.common.fp16:
                 assert not cfg.common.amp, "Cannot use fp16 and AMP together"
                 self._criterion = self._criterion.half()
@@ -197,16 +197,14 @@ class Trainer(object):
         return (
             self.data_parallel_world_size > 1 and not self.cfg.optimization.use_bmuf
         ) or (
-            self.cfg.distributed_training.ddp_backend == "fully_sharded"
-            and self.cfg.distributed_training.cpu_offload
+            self.is_fsdp and self.cfg.distributed_training.cpu_offload
         )
 
     @property
     def should_save_checkpoint_on_current_rank(self) -> bool:
         """Indicates whether to save checkpoints on the current DDP rank."""
         if (
-            self.cfg.distributed_training.ddp_backend == "fully_sharded"
-            and self.cfg.distributed_training.use_sharded_state
+            self.is_fsdp and self.cfg.distributed_training.use_sharded_state
         ) or getattr(self.cfg.model, "base_layers", 0) > 0:
             return True
         else:
@@ -214,10 +212,7 @@ class Trainer(object):
 
     @property
     def always_call_state_dict_during_save_checkpoint(self) -> bool:
-        if (
-            self.cfg.distributed_training.ddp_backend == "fully_sharded"
-            and not self.cfg.distributed_training.use_sharded_state
-        ):
+        if self.is_fsdp and not self.cfg.distributed_training.use_sharded_state:
             # FSDP calls communication collective when consolidating checkpoints
             return True
         else:
@@ -226,10 +221,7 @@ class Trainer(object):
     @property
     def checkpoint_suffix(self) -> str:
         """Suffix to add to the checkpoint file name."""
-        if (
-            self.cfg.distributed_training.ddp_backend == "fully_sharded"
-            and self.cfg.distributed_training.use_sharded_state
-        ):
+        if self.is_fsdp and self.cfg.distributed_training.use_sharded_state:
             return self.cfg.checkpoint.checkpoint_suffix + "-shard{0}".format(
                 self.data_parallel_rank
             )
@@ -284,10 +276,7 @@ class Trainer(object):
             )
         )
 
-        if (
-            self.cfg.distributed_training.ddp_backend == "fully_sharded"
-            and self.cfg.common.fp16
-        ):
+        if self.is_fsdp and self.cfg.common.fp16:
             # FullyShardedDataParallel always uses MemoryEfficientFP16 wrapper,
             # mostly for the grad scaling. But if we don't have the
             # --memory-efficient-fp16 flag set, then we're effectively doing
@@ -319,7 +308,7 @@ class Trainer(object):
                 logger.info("NOTE: your device may support faster training with --fp16 or --amp")
             self._optimizer = optim.build_optimizer(self.cfg.optimizer, params)
 
-        if self.cfg.distributed_training.ddp_backend == "fully_sharded":
+        if self.is_fsdp:
             assert (
                 not self.cfg.optimization.use_bmuf
             ), "--ddp-backend=fully_sharded is not compatible with BMUF"
@@ -357,6 +346,10 @@ class Trainer(object):
         )
         self._lr_scheduler.step_update(0)
 
+    @property
+    def is_fsdp(self):
+        return self.cfg.distributed_training.ddp_backend == "fully_sharded"
+
     def consolidate_optimizer(self):
         """For OSS, we need to consolidate the state dict."""
         if self.cfg.checkpoint.no_save_optimizer_state:
@@ -364,11 +357,7 @@ class Trainer(object):
         self._gathered_optim_state = None
         if hasattr(self.optimizer.optimizer, "consolidate_state_dict"):
             self.optimizer.optimizer.consolidate_state_dict()
-
-        elif (
-            self.cfg.distributed_training.ddp_backend == "fully_sharded"
-            and not self.model.use_sharded_state
-        ):
+        elif self.is_fsdp and not self.model.use_sharded_state:
             st = self.model.gather_full_optim_state_dict(
                 self.optimizer
             )  # only returns on rank 0
@@ -409,7 +398,7 @@ class Trainer(object):
                 self._gathered_optim_state = None
             else:
                 state_dict["last_optimizer_state"] = self.optimizer.state_dict()
-        if self.cfg.distributed_training.ddp_backend == "fully_sharded":
+        if self.is_fsdp:
             # save meta data for recombining checkpoint upon loading
             state_dict["fsdp_metadata"] = self.model.local_metadata_dict()
         return state_dict
@@ -453,10 +442,7 @@ class Trainer(object):
                 # on every worker for now
                 or self.tpu
                 # FSDP requires loading checkpoint shards on all ranks
-                or (
-                    self.cfg.distributed_training.ddp_backend == "fully_sharded"
-                    and self.cfg.distributed_training.use_sharded_state
-                )
+                or (self.is_fsdp and self.cfg.distributed_training.use_sharded_state)
                 or getattr(self.cfg.model, "base_layers", 0) > 0
             )
 
@@ -527,10 +513,7 @@ class Trainer(object):
             if not reset_lr_scheduler:
                 self.lr_scheduler.load_state_dict(last_optim["lr_scheduler_state"])
 
-            if (
-                self.cfg.distributed_training.ddp_backend == "fully_sharded"
-                and not self.model.use_sharded_state
-            ):
+            if self.is_fsdp and not self.model.use_sharded_state:
                 # if use_sharded_state, the last_optim_state is already sharded, skip this
                 last_optim_state = self.model.get_shard_from_optim_state_dict(
                     last_optim_state
@@ -1112,7 +1095,7 @@ class Trainer(object):
             return total_norm ** 0.5
 
         should_agg_norm = (
-            self.cfg.distributed_training.ddp_backend == "fully_sharded"
+            self.is_fsdp
             and (
                 self.data_parallel_process_group is not None
                 or torch.distributed.is_initialized()


### PR DESCRIPTION
Previously combining FSDP with `--update-freq` would result in significant memory usage because full-size gradients would be accumulated on each GPU. We can instead skip the `no_sync` context manager in this case. The tradeoff is more communication (we do reduce-scatter on each backward), but the memory savings are likely to be worth it in most cases.