### PR TITLE
Fix output_text_file path when --dataset-impl=raw and --only-source

### DIFF
--- a/fairseq_cli/preprocess.py
+++ b/fairseq_cli/preprocess.py
@@ -252,10 +252,7 @@ def main(args):
     def make_dataset(vocab, input_prefix, output_prefix, lang, num_workers=1):
         if args.dataset_impl == "raw":
             # Copy original text file to destination folder
-            output_text_file = dest_path(
-                output_prefix + ".{}-{}".format(args.source_lang, args.target_lang),
-                lang,
-            )
+            output_text_file = dataset_dest_prefix(args, output_prefix, lang)
             shutil.copyfile(file_name(input_prefix, lang), output_text_file)
         else:
             make_binary_dataset(vocab, input_prefix, output_prefix, lang, num_workers)


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?

When --dataset-impl=raw and --task=language_modeling, fairseq-train cause the following error
```FileNotFoundError: Dataset not found: valid (./input/data-bin/valid)```

Currently, make_dataset generates valid.None-None.
The PR fix that.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
