### PR TITLE
multilingual example: Fix download source for iwslt17

### DIFF
--- a/examples/translation/prepare-iwslt17-multilingual.sh
+++ b/examples/translation/prepare-iwslt17-multilingual.sh
@@ -24,41 +24,39 @@ mkdir -p "$ORIG" "$DATA"
 TRAIN_MINLEN=1  # remove sentences with <1 BPE token
 TRAIN_MAXLEN=250  # remove sentences with >250 BPE tokens
 
-URLS=(
-    "https://wit3.fbk.eu/archive/2017-01-trnted/texts/de/en/de-en.tgz"
-    "https://wit3.fbk.eu/archive/2017-01-trnted/texts/fr/en/fr-en.tgz"
-)
-ARCHIVES=(
-    "de-en.tgz"
-    "fr-en.tgz"
-)
+URL="https://drive.google.com/uc?id=1gFeuPTRc3RB4DhJEkhr8O-a8PObM7Ix2"
+
+ARCHIVE="2017-01-trnted.tgz"
+
 VALID_SETS=(
     "IWSLT17.TED.dev2010.de-en IWSLT17.TED.tst2010.de-en IWSLT17.TED.tst2011.de-en IWSLT17.TED.tst2012.de-en IWSLT17.TED.tst2013.de-en IWSLT17.TED.tst2014.de-en IWSLT17.TED.tst2015.de-en"
     "IWSLT17.TED.dev2010.fr-en IWSLT17.TED.tst2010.fr-en IWSLT17.TED.tst2011.fr-en IWSLT17.TED.tst2012.fr-en IWSLT17.TED.tst2013.fr-en IWSLT17.TED.tst2014.fr-en IWSLT17.TED.tst2015.fr-en"
 )
 
-# download and extract data
-for ((i=0;i<${#URLS[@]};++i)); do
-    ARCHIVE=$ORIG/${ARCHIVES[i]}
-    if [ -f "$ARCHIVE" ]; then
-        echo "$ARCHIVE already exists, skipping download"
-    else
-        URL=${URLS[i]}
-        wget -P "$ORIG" "$URL"
-        if [ -f "$ARCHIVE" ]; then
-            echo "$URL successfully downloaded."
-        else
-            echo "$URL not successfully downloaded."
-            exit 1
+echo "downloading data..."
+pip install gdown
+if [ -f "$ARCHIVE" ]; then
+    echo "$ARCHIVE already exists, skipping download"
+else
+    gdown "$URL"
+fi
+
+if [ -e "2017-01-trnted" ]; then
+    echo "2017-01-trnted already exists, skipping extraction"
+else
+    tar -xzvf "$ARCHIVE"
+fi
+
+for SRC in "${SRCS[@]}"; do
+    for LANG in "${SRC}" "${TGT}"; do
+        if [ -e "$ORIG/$SRC-TGT" ]; then
+            echo "$ORIG/$SRC-TGT already exists, skipping extraction"
+	else
+            tar -C "$ORIG" -xzvf "2017-01-trnted/texts/$SRC/$TGT/$SRC-$TGT.tgz"
         fi
-    fi
-    FILE=${ARCHIVE: -4}
-    if [ -e "$FILE" ]; then
-        echo "$FILE already exists, skipping extraction"
-    else
-        tar -C "$ORIG" -xzvf "$ARCHIVE"
-    fi
+    done
 done
+
 
 echo "pre-processing train data..."
 for SRC in "${SRCS[@]}"; do


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  

## What does this PR do?
Fixes https://github.com/pytorch/fairseq/issues/3623

## PR review    
Fixes the example script for multilingual translation using iwslt17 data. The https://wit3.fbk.eu/archive/2017-01-trnted/* links now throw a 404, and the [WIT3 website page](https://wit3.fbk.eu/2017-01) now points to a Google Drive link that has all 2017-01-trnted data in one tgz file. So this PR:
- switches download to use Google Drive, using `gdown`
- extracts the relevant SRC-TGT files before preprocessing

Could confirm that `bash prepare-iwslt17-multilingual.sh` runs without errors using this fix. It is also idempotent.