### PR TITLE
Fix task/translation.py reducemetric bleu issue #3338 

### DIFF
--- a/fairseq/tasks/translation.py
+++ b/fairseq/tasks/translation.py
@@ -435,6 +435,12 @@ class TranslationTask(FairseqTask):
                     return round(bleu.score, 2)
 
                 metrics.log_derived("bleu", compute_bleu)
+            else:
+                def zero_bleu(meters):
+                    return 0.0
+                
+                metrics.log_derived("bleu", zero_bleu)
+                
 
     def max_positions(self):
         """Return the max sentence length allowed by the task."""


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?
Fixes # 3338.
If the translation model works so bad, the `max(totals)` becomes 0. 
When this case, if the args `best-checkpoint-metric bleu` givens the training system produces an error. 
I try to fix this problem by logging zero bleu when max(totals) `<= 0` case. 


## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
