### PR TITLE
Set batch size to 4 to prevent OOM due dynamic batch sizing

### DIFF
--- a/examples/wav2vec/config/pretraining/wav2vec2_large_librivox.yaml
+++ b/examples/wav2vec/config/pretraining/wav2vec2_large_librivox.yaml
@@ -18,6 +18,7 @@ task:
   normalize: true
 
 dataset:
+  batch_size: 4
   num_workers: 6
   max_tokens: 1200000
   skip_invalid_size_inputs_valid_test: true


### PR DESCRIPTION
## What does this PR do?
Fixes OOM which happens from TPUs due to dynamic batching exceed the max a single core can work with.
