### PR TITLE
Clear tensorboard writers after training

### DIFF
--- a/fairseq/logging/progress_bar.py
+++ b/fairseq/logging/progress_bar.py
@@ -21,7 +21,6 @@ import torch
 
 from .meters import AverageMeter, StopwatchMeter, TimeMeter
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -62,6 +61,7 @@ def progress_bar(
         try:
             # [FB only] custom wrapper for TensorBoard
             import palaas  # noqa
+
             from .fb_tbmf_wrapper import FbTbmfWrapper
 
             bar = FbTbmfWrapper(bar, log_interval)
@@ -324,6 +324,9 @@ def _close_writers():
     for w in _tensorboard_writers.values():
         w.close()
 
+def clear_tb_writers():
+    _close_writers()
+    _tensorboard_writers.clear()
 
 atexit.register(_close_writers)
 

--- a/fairseq_cli/train.py
+++ b/fairseq_cli/train.py
@@ -12,7 +12,9 @@ import logging
 import math
 import os
 import sys
-from typing import Dict, Optional, Any, List, Tuple, Callable
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from fairseq.logging.progress_bar import clear_tb_writers
 
 # We need to setup root logger before importing any fairseq libraries.
 logging.basicConfig(
@@ -25,25 +27,18 @@ logger = logging.getLogger("fairseq_cli.train")
 
 import numpy as np
 import torch
-from fairseq import (
-    checkpoint_utils,
-    options,
-    quantization_utils,
-    tasks,
-    utils,
-)
-from fairseq.data import iterators, data_utils
+from fairseq import checkpoint_utils, options, quantization_utils, tasks, utils
+from fairseq.data import data_utils, iterators
 from fairseq.data.plasma_utils import PlasmaStore
 from fairseq.dataclass.configs import FairseqConfig
 from fairseq.dataclass.utils import convert_namespace_to_omegaconf
-from fairseq.distributed import fsdp_enable_wrap, fsdp_wrap, utils as distributed_utils
+from fairseq.distributed import fsdp_enable_wrap, fsdp_wrap
+from fairseq.distributed import utils as distributed_utils
 from fairseq.file_io import PathManager
 from fairseq.logging import meters, metrics, progress_bar
 from fairseq.model_parallel.megatron_trainer import MegatronTrainer
 from fairseq.trainer import Trainer
 from omegaconf import DictConfig, OmegaConf
-
-
 
 
 def main(cfg: FairseqConfig) -> None:
@@ -193,6 +188,7 @@ def main(cfg: FairseqConfig) -> None:
         )
     train_meter.stop()
     logger.info("done training in {:.1f} seconds".format(train_meter.sum))
+    clear_tb_writers()
 
     # ioPath implementation to wait for all asynchronous file writes to complete.
     if cfg.checkpoint.write_checkpoints_asynchronously:


### PR DESCRIPTION
## What does this PR do?
Fixes #3817 

This PR always clears https://github.com/pytorch/fairseq/blob/1f7ef9ed1e1061f8c7f88f8b94c7186834398690/fairseq/logging/progress_bar.py#L314

after training is done, also in the case when they were not used (something to take into account)
