### PR TITLE
Support Chinese and Japanese for eval-bleu in validation

### DIFF
--- a/fairseq/tasks/translation.py
+++ b/fairseq/tasks/translation.py
@@ -493,5 +493,5 @@ class TranslationTask(FairseqTask):
             if self.cfg.target_lang == 'zh' and self.cfg.eval_bleu_tokenizer != 'zh':
                 logger.warning("You should use the 'zh' tokenizer for Chinese. Use --eval-bleu-tokenizer zh")
             if self.cfg.target_lang == 'ja' and self.cfg.eval_bleu_tokenizer != 'ja-mecab':
-                logger.warning("You should use the 'ja-mecab' tokenizer for Chinese. Use --eval-bleu-tokenizer ja-mecab")
+                logger.warning("You should use the 'ja-mecab' tokenizer for Japanese. Use --eval-bleu-tokenizer ja-mecab")
             return sacrebleu.corpus_bleu(hyps, [refs], tokenize=self.cfg.eval_bleu_tokenizer)

--- a/fairseq/tasks/translation.py
+++ b/fairseq/tasks/translation.py
@@ -262,6 +262,12 @@ class TranslationConfig(FairseqDataclass):
     eval_bleu_print_samples: bool = field(
         default=False, metadata={"help": "print sample generations during validation"}
     )
+    eval_bleu_tokenizer: Optional[str] = field(
+        default='13a',
+        metadata={
+            "help": "Tokenization method to use for SacreBLEU. Specific `zh` for Chinese and `ja-mecab` for Japanese . Choices: {none,zh,13a,char,intl,ja-mecab}"
+        }
+    )
 
 
 @register_task("translation", dataclass=TranslationConfig)
@@ -484,4 +490,8 @@ class TranslationTask(FairseqTask):
         if self.cfg.eval_tokenized_bleu:
             return sacrebleu.corpus_bleu(hyps, [refs], tokenize="none")
         else:
-            return sacrebleu.corpus_bleu(hyps, [refs])
+            if self.cfg.target_lang == 'zh' and self.cfg.eval_bleu_tokenizer != 'zh':
+                logger.warning("You should use the 'zh' tokenizer for Chinese. Use --eval-bleu-tokenizer zh")
+            if self.cfg.target_lang == 'ja' and self.cfg.eval_bleu_tokenizer != 'ja-mecab':
+                logger.warning("You should use the 'ja-mecab' tokenizer for Chinese. Use --eval-bleu-tokenizer ja-mecab")
+            return sacrebleu.corpus_bleu(hyps, [refs], tokenize=self.cfg.eval_bleu_tokenizer)


### PR DESCRIPTION
# Before submitting

- [No] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [Yes] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [No need] Did you make sure to update the docs?   
- [No need] Did you write any new necessary tests?  

## What does this PR do?
Add `--eval-bleu-tokenizer` to support Chinese and Japanese in training time bleu evaluation.  

```python
eval_bleu_tokenizer: Optional[str] = field(
    default='13a',
    metadata={"help": "Tokenization method to use for SacreBLEU. Specific `zh` for Chinese and `ja-mecab` for Japanese . Choices: {none,zh,13a,char,intl,ja-mecab}"}
)
```
 
Translation task supports eval-bleu using sacrebleu. But when target language is something like Chinese or Japanese, which is not space split, the default tokenizer `13a` can't tokenize sentences correctly. 

 When scoring Chinese and Japanese, `sacrebleu` need `--tokenize` to specify `zh` or `ja-mecab`. So I add `--eval-bleu-tokenizer` just like the [sacrebleu](https://github.com/mjpost/sacrebleu/)'s argument
```
--tokenize {none,zh,13a,char,intl,ja-mecab}, -tok {none,zh,13a,char,intl,ja-mecab}
                        Tokenization method to use for BLEU. If not provided, defaults to `zh` for Chinese, `ja-mecab` for Japanese and `13a` (mteval) otherwise.
```

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Yes