### PR TITLE
Bug fix for Speech-to-text data pipeline : fucntion name error inside audio_utils.py

### DIFF
--- a/fairseq/data/audio/audio_utils.py
+++ b/fairseq/data/audio/audio_utils.py
@@ -33,7 +33,7 @@ def _sox_convert(
     return ta_sox.apply_effects_tensor(waveform, sample_rate, effects)[0]
 
 
-def convert_to_mono(waveform: np.ndarray, sample_rate: int) -> np.ndarray:
+def _convert_to_mono(waveform: np.ndarray, sample_rate: int) -> np.ndarray:
     if waveform.shape[0] > 1:
         _waveform = torch.from_numpy(waveform)
         effects = [["channels", "1"]]
@@ -79,7 +79,7 @@ def get_waveform(
     )
     waveform = waveform.T  # T x C -> C x T
     if mono and waveform.shape[0] > 1:
-        waveform = convert_to_mono(waveform, sample_rate)
+        waveform = _convert_to_mono(waveform, sample_rate)
     if output_sample_rate > 0:
         waveform = update_sample_rate(waveform, sample_rate, output_sample_rate)
         sample_rate = output_sample_rate


### PR DESCRIPTION
Fix fucntion name error of convert_to_mono in audio_utils.py to match its usage in data_utils.py

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?
Fixes # (issue).
Minor bug fix for Speech-to-text datapipeline.
Fix fucntion name error of function convert_to_mono in data/audio/audio_utils.py file to match the function name inside examples/speech_to_text/data_utils.py file.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
