### PR TITLE
Update setup.py for sacrebleu incompatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -206,7 +206,7 @@ def do_setup(package_data):
             'numpy<1.20.0; python_version<"3.7"',
             'numpy; python_version>="3.7"',
             "regex",
-            "sacrebleu>=1.4.12",
+            "sacrebleu>=1.4.12,<2.0",
             "torch",
             "tqdm",
             "bitarray",


### PR DESCRIPTION
Sacrebleu 2 is not compatible with fairseq (see here: https://github.com/pytorch/fairseq/blob/f6abcc2a67328bee8b15c596bb626ce2d720aae6/fairseq/scoring/tokenizer.py#L36)
And here: https://github.com/facebookresearch/vizseq/issues/29#issuecomment-609444573 
So we should just fix the dependency to a version which works.
Generally doing ">=" and assuming future versions don't break anything is not a good idea.